### PR TITLE
ci: exclude CHANGELOG.md from deno fmt

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -34,7 +34,8 @@
     "indentWidth": 2,
     "semiColons": true,
     "singleQuote": false,
-    "proseWrap": "preserve"
+    "proseWrap": "preserve",
+    "exclude": ["**/CHANGELOG.md"]
   },
   "lint": {
     "include": ["packages/"],


### PR DESCRIPTION
## Summary

- Exclude `**/CHANGELOG.md` from `deno fmt` in root `deno.json`
- release-please generates CHANGELOGs with markdown formatting (`*` lists, extra blank lines) that conflicts with `deno fmt`, causing CI failures on release PRs

## Related Issues

Fixes CI failure on release-please PR #4

## Test Plan

- [ ] `deno fmt --check` passes
- [ ] Release PR #4 CI passes after this is merged and the release branch is rebased

## Checklist

- [x] `deno check` passes
- [x] `deno fmt` passes
- [x] `deno lint` passes
- [x] `deno test --allow-net` passes
- [ ] README/CLAUDE.md updated (if tools or resources changed)