### PR TITLE
chore: update all dependencies to latest and hoist shared imports

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -42,5 +42,9 @@
     "rules": {
       "tags": ["recommended"]
     }
+  },
+  "imports": {
+    "@logtape/logtape": "jsr:@logtape/logtape@^2.0.4",
+    "@std/assert": "jsr:@std/assert@^1.0.19"
   }
 }

--- a/deno.lock
+++ b/deno.lock
@@ -7,10 +7,12 @@
     "jsr:@cliffy/table@1.0.0": "1.0.0",
     "jsr:@logtape/logtape@^2.0.4": "2.0.4",
     "jsr:@std/assert@1": "1.0.19",
+    "jsr:@std/assert@^1.0.19": "1.0.19",
     "jsr:@std/dotenv@~0.225.6": "0.225.6",
     "jsr:@std/fmt@^1.0.9": "1.0.9",
     "jsr:@std/internal@^1.0.12": "1.0.12",
     "jsr:@std/text@^1.0.17": "1.0.17",
+    "npm:@modelcontextprotocol/sdk@*": "1.27.1_zod@4.3.6_hono@4.12.3_ajv@8.18.0_express@5.2.1",
     "npm:@modelcontextprotocol/sdk@^1.27.1": "1.27.1_zod@4.3.6_hono@4.12.3_ajv@8.18.0_express@5.2.1",
     "npm:zod@^4.3.6": "4.3.6"
   },
@@ -577,34 +579,17 @@
     }
   },
   "workspace": {
+    "dependencies": [
+      "jsr:@logtape/logtape@^2.0.4",
+      "jsr:@std/assert@^1.0.19"
+    ],
     "members": {
       "packages/media-server-mcp": {
         "dependencies": [
           "jsr:@cliffy/command@1",
-          "jsr:@logtape/logtape@^2.0.4",
           "jsr:@std/dotenv@~0.225.6",
           "npm:@modelcontextprotocol/sdk@^1.27.1",
           "npm:zod@^4.3.6"
-        ]
-      },
-      "packages/plex": {
-        "dependencies": [
-          "jsr:@logtape/logtape@^2.0.4"
-        ]
-      },
-      "packages/radarr": {
-        "dependencies": [
-          "jsr:@logtape/logtape@^2.0.4"
-        ]
-      },
-      "packages/sonarr": {
-        "dependencies": [
-          "jsr:@logtape/logtape@^2.0.4"
-        ]
-      },
-      "packages/tmdb": {
-        "dependencies": [
-          "jsr:@logtape/logtape@^2.0.4"
         ]
       }
     }

--- a/packages/media-server-mcp/deno.json
+++ b/packages/media-server-mcp/deno.json
@@ -22,8 +22,7 @@
     "@modelcontextprotocol/sdk": "npm:@modelcontextprotocol/sdk@^1.27.1",
     "@std/dotenv": "jsr:@std/dotenv@^0.225.6",
     "zod": "npm:zod@^4.3.6",
-    "@cliffy/command": "jsr:@cliffy/command@^1.0.0",
-    "@logtape/logtape": "jsr:@logtape/logtape@^2.0.4"
+    "@cliffy/command": "jsr:@cliffy/command@^1.0.0"
   },
   "repository": {
     "type": "git",

--- a/packages/media-server-mcp/tests/auth_test.ts
+++ b/packages/media-server-mcp/tests/auth_test.ts
@@ -1,4 +1,4 @@
-import { assertEquals } from "jsr:@std/assert@^1.0.0";
+import { assertEquals } from "@std/assert";
 import { validateBearerToken } from "../src/auth.ts";
 
 Deno.test("validateBearerToken - returns true for a valid Bearer token", () => {

--- a/packages/media-server-mcp/tests/server_test.ts
+++ b/packages/media-server-mcp/tests/server_test.ts
@@ -1,4 +1,4 @@
-import { assertEquals } from "jsr:@std/assert@^1.0.0";
+import { assertEquals } from "@std/assert";
 
 // Simple integration test to verify the main module can be imported
 Deno.test("index.ts - can be imported without errors", () => {

--- a/packages/media-server-mcp/tests/sse-transport_test.ts
+++ b/packages/media-server-mcp/tests/sse-transport_test.ts
@@ -1,4 +1,4 @@
-import { assertEquals, assertExists } from "jsr:@std/assert@^1.0.0";
+import { assertEquals, assertExists } from "@std/assert";
 
 // Tests for SSE transport functionality
 Deno.test("SSE transport module - can be imported without errors", async () => {

--- a/packages/media-server-mcp/tests/streamable-http-transport_test.ts
+++ b/packages/media-server-mcp/tests/streamable-http-transport_test.ts
@@ -1,4 +1,4 @@
-import { assertEquals } from "jsr:@std/assert@^1.0.0";
+import { assertEquals } from "@std/assert";
 
 Deno.test("Streamable HTTP transport module - can be imported without errors", async () => {
   const { createStreamableHTTPServer } = await import(

--- a/packages/media-server-mcp/tests/tools/radarr-tools_test.ts
+++ b/packages/media-server-mcp/tests/tools/radarr-tools_test.ts
@@ -1,4 +1,4 @@
-import { assertEquals } from "jsr:@std/assert@^1.0.0";
+import { assertEquals } from "@std/assert";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { createRadarrTools } from "../../src/tools/radarr-tools.ts";
 import { createRadarrConfig } from "@wyattjoh/radarr";

--- a/packages/media-server-mcp/tests/tools/sonarr-tools_test.ts
+++ b/packages/media-server-mcp/tests/tools/sonarr-tools_test.ts
@@ -1,4 +1,4 @@
-import { assertEquals } from "jsr:@std/assert@^1.0.0";
+import { assertEquals } from "@std/assert";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { createSonarrTools } from "../../src/tools/sonarr-tools.ts";
 import { createSonarrConfig } from "@wyattjoh/sonarr";

--- a/packages/media-server-mcp/tests/tools/tmdb-tools_test.ts
+++ b/packages/media-server-mcp/tests/tools/tmdb-tools_test.ts
@@ -1,4 +1,4 @@
-import { assertEquals } from "jsr:@std/assert@^1.0.0";
+import { assertEquals } from "@std/assert";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { createTMDBTools } from "../../src/tools/tmdb-tools.ts";
 import { createTMDBConfig } from "@wyattjoh/tmdb";

--- a/packages/plex/deno.json
+++ b/packages/plex/deno.json
@@ -3,9 +3,6 @@
   "version": "0.4.0",
   "license": "MIT",
   "exports": "./mod.ts",
-  "imports": {
-    "@logtape/logtape": "jsr:@logtape/logtape@^2.0.4"
-  },
   "publish": {
     "include": [
       "LICENSE",

--- a/packages/plex/tests/client_test.ts
+++ b/packages/plex/tests/client_test.ts
@@ -1,8 +1,4 @@
-import {
-  assertEquals,
-  assertExists,
-  assertRejects,
-} from "jsr:@std/assert@^1.0.0";
+import { assertEquals, assertExists, assertRejects } from "@std/assert";
 import {
   addToCollection,
   createCollection,

--- a/packages/radarr/deno.json
+++ b/packages/radarr/deno.json
@@ -3,9 +3,6 @@
   "version": "1.0.0",
   "license": "MIT",
   "exports": "./mod.ts",
-  "imports": {
-    "@logtape/logtape": "jsr:@logtape/logtape@^2.0.4"
-  },
   "publish": {
     "include": [
       "LICENSE",

--- a/packages/radarr/tests/client_test.ts
+++ b/packages/radarr/tests/client_test.ts
@@ -1,4 +1,4 @@
-import { assertEquals } from "jsr:@std/assert@^1.0.0";
+import { assertEquals } from "@std/assert";
 import { createRadarrConfig, testConnection } from "../mod.ts";
 
 Deno.test("createRadarrConfig - creates valid config", () => {

--- a/packages/radarr/tests/filters_test.ts
+++ b/packages/radarr/tests/filters_test.ts
@@ -1,4 +1,4 @@
-import { assertEquals } from "jsr:@std/assert@^1.0.0";
+import { assertEquals } from "@std/assert";
 import { applyRadarrMovieFilters, type RadarrMovie } from "../mod.ts";
 
 Deno.test("applyRadarrMovieFilters - filter by imdbId", () => {

--- a/packages/sonarr/deno.json
+++ b/packages/sonarr/deno.json
@@ -3,9 +3,6 @@
   "version": "1.0.0",
   "license": "MIT",
   "exports": "./mod.ts",
-  "imports": {
-    "@logtape/logtape": "jsr:@logtape/logtape@^2.0.4"
-  },
   "publish": {
     "include": [
       "LICENSE",

--- a/packages/sonarr/tests/client_test.ts
+++ b/packages/sonarr/tests/client_test.ts
@@ -1,4 +1,4 @@
-import { assertEquals } from "jsr:@std/assert@^1.0.0";
+import { assertEquals } from "@std/assert";
 import { createSonarrConfig, testConnection } from "../mod.ts";
 
 Deno.test("createSonarrConfig - creates valid config", () => {

--- a/packages/sonarr/tests/filters_test.ts
+++ b/packages/sonarr/tests/filters_test.ts
@@ -1,4 +1,4 @@
-import { assertEquals } from "jsr:@std/assert@^1.0.0";
+import { assertEquals } from "@std/assert";
 import { applySonarrSeriesFilters, type SonarrSeries } from "../mod.ts";
 
 Deno.test("applySonarrSeriesFilters - filter by imdbId", () => {

--- a/packages/tmdb/deno.json
+++ b/packages/tmdb/deno.json
@@ -3,9 +3,6 @@
   "version": "1.0.0",
   "license": "MIT",
   "exports": "./mod.ts",
-  "imports": {
-    "@logtape/logtape": "jsr:@logtape/logtape@^2.0.4"
-  },
   "publish": {
     "include": [
       "LICENSE",


### PR DESCRIPTION
## Summary

- Hoist `@logtape/logtape` from 5 per-package `deno.json` imports to root workspace `deno.json`
- Hoist `@std/assert` from inline test file imports to root workspace `deno.json`
- Update 12 test files to use bare `@std/assert` specifier instead of versioned inline imports
- All existing dependency versions confirmed at latest

## Test plan

- [ ] `deno check` passes
- [ ] `deno fmt --check` passes
- [ ] `deno lint` passes
- [ ] `deno test --allow-net --allow-env` passes
- [ ] `deno publish --dry-run` passes for all 5 packages