### PR TITLE
feat: MCP improvements - resources, prompts, annotations, structured output, error handling

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,7 +69,7 @@ Each package is independently publishable and has its own `deno.json` configurat
 
 ## Architecture Overview
 
-This is a **Model Context Protocol (MCP) server** that provides AI assistants with tools to manage Radarr (movies), Sonarr (TV series), and Plex media servers, and access TMDB data through their APIs.
+This is a **Model Context Protocol (MCP) server** that provides AI assistants with tools, resources, and prompts to manage Radarr (movies), Sonarr (TV series), and Plex media servers, and access TMDB data through their APIs.
 
 ### Core Architecture Pattern
 
@@ -77,13 +77,15 @@ The codebase follows a **layered architecture**:
 
 1. **MCP Server Layer** (`packages/media-server-mcp/src/index.ts`): Main server that handles MCP protocol communication
 2. **Tool Layer** (`packages/media-server-mcp/src/tools/`): MCP tool definitions and handlers that bridge MCP and API clients
-3. **Client Packages** (`packages/{radarr,sonarr,tmdb,plex}/`): Standalone client libraries for each service
-4. **Type Definitions**: Each package contains its own TypeScript definitions
-5. **Shared Components**: Client packages include filtering and validation utilities
+3. **Resource Layer** (`packages/media-server-mcp/src/resources/`): MCP resources that expose service configs and dynamic data as readable URIs
+4. **Prompt Layer** (`packages/media-server-mcp/src/prompts/`): MCP prompts for common media management workflows
+5. **Client Packages** (`packages/{radarr,sonarr,tmdb,plex}/`): Standalone client libraries for each service
+6. **Type Definitions**: Each package contains its own TypeScript definitions
+7. **Shared Components**: Client packages include filtering and validation utilities
 
 ### Key Architectural Decisions
 
-**Direct Tool Registration**: Tools are registered directly on the `McpServer` instance via `createRadarrTools()`, `createSonarrTools()`, `createTMDBTools()`, and `createPlexTools()` functions. Each function accepts the server, service config, and a tool filter function, then registers tools as side effects using `server.registerTool()`. Tool handlers are closures that capture the service config at registration time.
+**Direct Tool Registration**: Tools are registered directly on the `McpServer` instance via `createRadarrTools()`, `createSonarrTools()`, `createTMDBTools()`, and `createPlexTools()` functions. Each function accepts the server, service config, and a tool filter function, then registers tools as side effects using `server.registerTool()`. Tool handlers are closures that capture the service config at registration time. All tool handlers are wrapped with `wrapToolHandler()` from `tool-wrapper.ts`, which centralizes error handling (returning `isError: true` on failure), logging, and execution timing. Individual tool handlers do not need their own try/catch blocks.
 
 **Tool Filtering System**: A configurable tool filtering system (`tool-categories.ts`, `tool-filter.ts`) allows enabling/disabling tools via profiles, branches, include/exclude lists, or config files. This controls which tools are registered on the server.
 
@@ -137,7 +139,7 @@ This codebase **ALWAYS** follows a **functional architecture** approach rather t
 ### Error Handling Pattern
 
 - Unknown errors must be handled with `error instanceof Error ? error.message : String(error)`
-- Tool handlers catch all errors and return error results with `isError: true`
+- Tool error handling is centralized in `wrapToolHandler()` (`tool-wrapper.ts`). It catches all errors and returns `isError: true` with the error message. Individual tool handlers should not wrap their own logic in try/catch.
 - Connection testing on startup logs warnings but doesn't prevent server launch
 
 ## Environment Variables
@@ -182,10 +184,12 @@ TOOL_CONFIG_PATH=./tools.json # Path to JSON configuration file for tool setting
 - The server tests API connections on startup but continues running even if services are unavailable
 - Tools are registered directly on the `McpServer` via `server.registerTool()` during setup
 - Each service's tools are only registered if that service is properly configured
+- All API client fetch calls use `AbortSignal.timeout(30_000)` to enforce a 30-second request timeout
 - Radarr and Sonarr use the same base URL + endpoint pattern with API key authentication via `X-Api-Key` header
 - TMDB uses direct API access with `Authorization: Bearer {api_key}` header authentication
 - Plex uses direct API access with `X-Plex-Token` header authentication
 - **SSE Mode Security**: SSE mode requires `MCP_AUTH_TOKEN` environment variable and validates Bearer tokens on all endpoints except `/health`
+- **SSE Deprecation**: SSE transport is deprecated. A warning is logged on startup when `--sse` is used. Prefer Streamable HTTP (`--http`) for remote deployments.
 - **Streamable HTTP Mode Security**: HTTP mode requires `MCP_AUTH_TOKEN` when binding to non-loopback addresses. When set, all endpoints except `/health` require a valid Bearer token. Localhost development (`--host 127.0.0.1`) can run without auth.
 
 ## Available Tools by Service
@@ -351,12 +355,46 @@ TOOL_CONFIG_PATH=./tools.json # Path to JSON configuration file for tool setting
 - `plex_remove_from_collection` - Remove a single item from a collection
 - `plex_delete_collection` - Delete an entire collection
 
+## Available Resources by Service
+
+MCP resources expose structured data as readable URIs. They are registered when the corresponding service is configured.
+
+### Radarr Resources (when `RADARR_URL` and `RADARR_API_KEY` are configured)
+
+- `config://radarr` - Radarr configuration (quality profiles, root folders, tags)
+- `radarr://movies/{movieId}` - Details for a specific movie by Radarr ID
+
+### Sonarr Resources (when `SONARR_URL` and `SONARR_API_KEY` are configured)
+
+- `config://sonarr` - Sonarr configuration (quality profiles, root folders, tags)
+- `sonarr://series/{seriesId}` - Details for a specific series by Sonarr ID
+
+### TMDB Resources (when `TMDB_API_KEY` is configured)
+
+- `config://tmdb` - TMDB API configuration (image base URLs, supported sizes)
+- `tmdb://genres/movies` - Full list of TMDB movie genres
+- `tmdb://genres/tv` - Full list of TMDB TV genres
+
+### Plex Resources (when `PLEX_URL` and `PLEX_API_KEY` are configured)
+
+- `plex://libraries` - All Plex library sections with metadata
+- `plex://collections/{collectionId}` - Items in a specific Plex collection
+
+## Available Prompts
+
+MCP prompts provide reusable, parameterized templates for common workflows. All 4 prompts are registered when at least one relevant service is configured.
+
+- `add-movie` - Guided workflow for searching and adding a movie (uses TMDB search + Radarr add)
+- `add-series` - Guided workflow for searching and adding a TV series (uses TMDB search + Sonarr add)
+- `library-report` - Generate a summary report of the current media library state across configured services
+- `recommendations` - Get personalized media recommendations based on existing library content
+
 ## Tool Implementation Pattern
 
 All tool files follow the same pattern:
 
-1. **Zod Schemas**: Define parameter validation schemas at the top
-2. **createXXXTools()**: Function that registers tools directly on the `McpServer`, checking `isToolEnabled()` before each registration
+1. **Zod Schemas**: Define parameter validation schemas and output schemas at the top
+2. **createXXXTools()**: Function that registers tools directly on the `McpServer`, checking `isToolEnabled()` before each registration. Each tool is registered with `annotations`, `outputSchema`, and a handler wrapped in `wrapToolHandler()`.
 3. **Single File**: Each service's tools are defined and registered from a single file
 
 Example structure:
@@ -364,6 +402,13 @@ Example structure:
 ```typescript
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
+import { wrapToolHandler } from "../tool-wrapper.ts";
+
+// Output schema for structured content
+const ServiceToolOutputSchema = z.object({
+  id: z.number(),
+  name: z.string(),
+});
 
 // Tool registration (with config injection and filtering)
 export function createServiceTools(
@@ -377,15 +422,25 @@ export function createServiceTools(
       {
         title: "Tool title",
         description: "Tool description",
+        annotations: {
+          readOnlyHint: true,
+          destructiveHint: false,
+          idempotentHint: true,
+          openWorldHint: false,
+        },
         inputSchema: {
           param: z.string().describe("Parameter description"),
         },
+        outputSchema: ServiceToolOutputSchema,
       },
-      async (args) => {
-        // Tool handler with config captured via closure
+      wrapToolHandler("service_tool_name", async (args) => {
+        // Tool handler with config captured via closure; no try/catch needed
         const result = await serviceClient.doSomething(config, args.param);
-        return { content: [{ type: "text", text: JSON.stringify(result) }] };
-      },
+        return {
+          content: [{ type: "text", text: JSON.stringify(result) }],
+          structuredContent: result,
+        };
+      }),
     );
   }
 }

--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ This is a monorepo containing the following packages:
 - **Plex Integration**: Browse libraries, search content, and manage Plex media server
 - **TMDB Integration**: Advanced movie/TV discovery, external ID lookup, and comprehensive metadata
 - **Tool Configuration System**: Reduce tool clutter with 6 profiles (18-70 tools) and branch-based filtering
+- **MCP Resources**: Expose service configs and dynamic data (movies, series, collections, genres) as readable resources
+- **MCP Prompts**: Built-in prompts for common workflows (add-movie, add-series, library-report, recommendations)
 - **Flexible Service Configuration**: Each service is optional - configure any combination
 - **Type-Safe**: Built with TypeScript for reliable operations
 - **Easy Setup**: Install directly from JSR with a single deno run command
@@ -159,6 +161,8 @@ Add to your MCP servers configuration using the JSR package:
 - **Remote with custom port**: `https://radarr.yourdomain.com:443`
 
 ### SSE Mode (HTTP Transport)
+
+> **Deprecated**: SSE transport is deprecated. Use Streamable HTTP (`--http`) instead.
 
 By default, the MCP server runs in stdio mode for direct integration with MCP clients. However, you can also run it in SSE (Server-Sent Events) mode over HTTP for web-based integrations or debugging.
 

--- a/deno.json
+++ b/deno.json
@@ -45,6 +45,7 @@
   },
   "imports": {
     "@logtape/logtape": "jsr:@logtape/logtape@^2.0.4",
-    "@std/assert": "jsr:@std/assert@^1.0.19"
+    "@std/assert": "jsr:@std/assert@^1.0.19",
+    "@std/testing": "jsr:@std/testing@^1.0.11"
   }
 }

--- a/deno.lock
+++ b/deno.lock
@@ -7,12 +7,15 @@
     "jsr:@cliffy/table@1.0.0": "1.0.0",
     "jsr:@logtape/logtape@^2.0.4": "2.0.4",
     "jsr:@std/assert@1": "1.0.19",
+    "jsr:@std/assert@^1.0.17": "1.0.19",
     "jsr:@std/assert@^1.0.19": "1.0.19",
     "jsr:@std/dotenv@~0.225.6": "0.225.6",
     "jsr:@std/fmt@^1.0.9": "1.0.9",
     "jsr:@std/internal@^1.0.12": "1.0.12",
+    "jsr:@std/testing@^1.0.11": "1.0.17",
     "jsr:@std/text@^1.0.17": "1.0.17",
     "npm:@modelcontextprotocol/sdk@*": "1.27.1_zod@4.3.6_hono@4.12.3_ajv@8.18.0_express@5.2.1",
+    "npm:@modelcontextprotocol/sdk@1.27.1": "1.27.1_zod@4.3.6_hono@4.12.3_ajv@8.18.0_express@5.2.1",
     "npm:@modelcontextprotocol/sdk@^1.27.1": "1.27.1_zod@4.3.6_hono@4.12.3_ajv@8.18.0_express@5.2.1",
     "npm:zod@^4.3.6": "4.3.6"
   },
@@ -60,6 +63,12 @@
     },
     "@std/internal@1.0.12": {
       "integrity": "972a634fd5bc34b242024402972cd5143eac68d8dffaca5eaa4dba30ce17b027"
+    },
+    "@std/testing@1.0.17": {
+      "integrity": "87bdc2700fa98249d48a17cd72413352d3d3680dcfbdb64947fd0982d6bbf681",
+      "dependencies": [
+        "jsr:@std/assert@^1.0.17"
+      ]
     },
     "@std/text@1.0.17": {
       "integrity": "4b2c4ef67ae5b6c1dfd447c81c83a43718f52e3c7e748d8b33f694aba9895f95"
@@ -581,7 +590,8 @@
   "workspace": {
     "dependencies": [
       "jsr:@logtape/logtape@^2.0.4",
-      "jsr:@std/assert@^1.0.19"
+      "jsr:@std/assert@^1.0.19",
+      "jsr:@std/testing@^1.0.11"
     ],
     "members": {
       "packages/media-server-mcp": {

--- a/packages/media-server-mcp/src/index.ts
+++ b/packages/media-server-mcp/src/index.ts
@@ -32,6 +32,14 @@ import { createRadarrTools } from "./tools/radarr-tools.ts";
 import { createSonarrTools } from "./tools/sonarr-tools.ts";
 import { createTMDBTools } from "./tools/tmdb-tools.ts";
 import { createPlexTools } from "./tools/plex-tools.ts";
+import { createRadarrResources } from "./resources/radarr-resources.ts";
+import { createSonarrResources } from "./resources/sonarr-resources.ts";
+import { createTMDBResources } from "./resources/tmdb-resources.ts";
+import { createPlexResources } from "./resources/plex-resources.ts";
+import { createAddMoviePrompt } from "./prompts/add-movie-prompt.ts";
+import { createAddSeriesPrompt } from "./prompts/add-series-prompt.ts";
+import { createLibraryReportPrompt } from "./prompts/library-report-prompt.ts";
+import { createRecommendationsPrompt } from "./prompts/recommendations-prompt.ts";
 import {
   createToolFilter,
   loadToolConfigFile,
@@ -75,6 +83,8 @@ async function createMcpServerWithTools(
     {
       capabilities: {
         tools: {},
+        resources: {},
+        prompts: {},
       },
     },
   );
@@ -213,6 +223,18 @@ async function setupTools(
   }
 
   logger.info("Tools registration completed");
+
+  // Register resources
+  if (config.radarrConfig) createRadarrResources(server, config.radarrConfig);
+  if (config.sonarrConfig) createSonarrResources(server, config.sonarrConfig);
+  if (config.tmdbConfig) createTMDBResources(server, config.tmdbConfig);
+  if (config.plexConfig) createPlexResources(server, config.plexConfig);
+
+  // Register prompts
+  if (config.radarrConfig) createAddMoviePrompt(server, config.radarrConfig);
+  if (config.sonarrConfig) createAddSeriesPrompt(server, config.sonarrConfig);
+  createLibraryReportPrompt(server);
+  createRecommendationsPrompt(server);
 }
 
 async function testConnections(

--- a/packages/media-server-mcp/src/index.ts
+++ b/packages/media-server-mcp/src/index.ts
@@ -233,8 +233,12 @@ async function setupTools(
   // Register prompts
   if (config.radarrConfig) createAddMoviePrompt(server, config.radarrConfig);
   if (config.sonarrConfig) createAddSeriesPrompt(server, config.sonarrConfig);
-  createLibraryReportPrompt(server);
-  createRecommendationsPrompt(server);
+  if (config.radarrConfig || config.sonarrConfig) {
+    createLibraryReportPrompt(server);
+  }
+  if (config.tmdbConfig) {
+    createRecommendationsPrompt(server);
+  }
 }
 
 async function testConnections(

--- a/packages/media-server-mcp/src/prompts/add-movie-prompt.ts
+++ b/packages/media-server-mcp/src/prompts/add-movie-prompt.ts
@@ -1,0 +1,41 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { RadarrConfig } from "@wyattjoh/radarr";
+import * as radarrClient from "@wyattjoh/radarr";
+
+export function createAddMoviePrompt(
+  server: McpServer,
+  config: Readonly<RadarrConfig>,
+): void {
+  server.registerPrompt(
+    "add-movie",
+    {
+      title: "Add a Movie",
+      description: "Guided workflow to search for and add a movie to Radarr",
+    },
+    async () => {
+      const [qualityProfiles, rootFolders] = await Promise.all([
+        radarrClient.getQualityProfiles(config),
+        radarrClient.getRootFolders(config),
+      ]);
+
+      return {
+        messages: [{
+          role: "user" as const,
+          content: {
+            type: "text" as const,
+            text:
+              `I want to add a movie to my library. Help me through these steps:\n1. Ask what movie I'm looking for\n2. Search TMDB using tmdb_search_movies\n3. Show results and let me pick\n4. Check if already in Radarr using radarr_get_movies\n5. Add using radarr_add_movie\n\nAvailable quality profiles: ${
+                JSON.stringify(
+                  qualityProfiles.map((p) => ({ id: p.id, name: p.name })),
+                )
+              }\nAvailable root folders: ${
+                JSON.stringify(
+                  rootFolders.map((f) => ({ id: f.id, path: f.path })),
+                )
+              }`,
+          },
+        }],
+      };
+    },
+  );
+}

--- a/packages/media-server-mcp/src/prompts/add-series-prompt.ts
+++ b/packages/media-server-mcp/src/prompts/add-series-prompt.ts
@@ -1,0 +1,42 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { SonarrConfig } from "@wyattjoh/sonarr";
+import * as sonarrClient from "@wyattjoh/sonarr";
+
+export function createAddSeriesPrompt(
+  server: McpServer,
+  config: Readonly<SonarrConfig>,
+): void {
+  server.registerPrompt(
+    "add-series",
+    {
+      title: "Add a TV Series",
+      description:
+        "Guided workflow to search for and add a TV series to Sonarr",
+    },
+    async () => {
+      const [qualityProfiles, rootFolders] = await Promise.all([
+        sonarrClient.getQualityProfiles(config),
+        sonarrClient.getRootFolders(config),
+      ]);
+
+      return {
+        messages: [{
+          role: "user" as const,
+          content: {
+            type: "text" as const,
+            text:
+              `I want to add a TV series to my library. Help me through these steps:\n1. Ask what series I'm looking for\n2. Search TMDB using tmdb_search_tv\n3. Show results and let me pick\n4. Check if already in Sonarr using sonarr_get_series\n5. Add using sonarr_add_series\n\nAvailable quality profiles: ${
+                JSON.stringify(
+                  qualityProfiles.map((p) => ({ id: p.id, name: p.name })),
+                )
+              }\nAvailable root folders: ${
+                JSON.stringify(
+                  rootFolders.map((f) => ({ id: f.id, path: f.path })),
+                )
+              }`,
+          },
+        }],
+      };
+    },
+  );
+}

--- a/packages/media-server-mcp/src/prompts/library-report-prompt.ts
+++ b/packages/media-server-mcp/src/prompts/library-report-prompt.ts
@@ -1,0 +1,21 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+
+export function createLibraryReportPrompt(server: McpServer): void {
+  server.registerPrompt(
+    "library-report",
+    {
+      title: "Library Report",
+      description: "Generate a summary of library status across all services",
+    },
+    () => ({
+      messages: [{
+        role: "user" as const,
+        content: {
+          type: "text" as const,
+          text:
+            "Generate a library report by:\n1. Get all movies from Radarr (radarr_get_movies)\n2. Get all series from Sonarr (sonarr_get_series)\n3. Summarize: total count, monitored vs unmonitored, any missing files\n4. Present a concise overview",
+        },
+      }],
+    }),
+  );
+}

--- a/packages/media-server-mcp/src/prompts/recommendations-prompt.ts
+++ b/packages/media-server-mcp/src/prompts/recommendations-prompt.ts
@@ -1,0 +1,22 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+
+export function createRecommendationsPrompt(server: McpServer): void {
+  server.registerPrompt(
+    "recommendations",
+    {
+      title: "Content Recommendations",
+      description:
+        "Get personalized movie and TV show recommendations based on your library",
+    },
+    () => ({
+      messages: [{
+        role: "user" as const,
+        content: {
+          type: "text" as const,
+          text:
+            "Help me find content recommendations based on my library:\n1. Get my current movies from Radarr (radarr_get_movies) and series from Sonarr (sonarr_get_series)\n2. Pick a few titles I have and use tmdb_get_movie_recommendations or tmdb_get_tv_recommendations\n3. Filter out anything I already own\n4. Present a curated list of recommendations with titles, overviews, and ratings",
+        },
+      }],
+    }),
+  );
+}

--- a/packages/media-server-mcp/src/resources/plex-resources.ts
+++ b/packages/media-server-mcp/src/resources/plex-resources.ts
@@ -1,0 +1,56 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { ResourceTemplate } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { PlexConfig } from "@wyattjoh/plex";
+import * as plexClient from "@wyattjoh/plex";
+
+export function createPlexResources(
+  server: McpServer,
+  config: Readonly<PlexConfig>,
+): void {
+  // Static resource: plex://libraries
+  server.registerResource(
+    "plex-libraries",
+    "plex://libraries",
+    {
+      description: "Available Plex libraries",
+      mimeType: "application/json",
+    },
+    async (uri) => {
+      const libraries = await plexClient.getLibraries(config);
+
+      return {
+        contents: [{
+          uri: uri.href,
+          text: JSON.stringify(libraries),
+          mimeType: "application/json",
+        }],
+      };
+    },
+  );
+
+  // Templated resource: plex://collections/{collectionId}
+  server.registerResource(
+    "plex-collection",
+    new ResourceTemplate("plex://collections/{collectionId}", {
+      list: undefined,
+    }),
+    {
+      description: "Items in a specific Plex collection",
+      mimeType: "application/json",
+    },
+    async (uri, { collectionId }) => {
+      const items = await plexClient.getCollectionItems(
+        config,
+        String(collectionId),
+      );
+
+      return {
+        contents: [{
+          uri: uri.href,
+          text: JSON.stringify(items),
+          mimeType: "application/json",
+        }],
+      };
+    },
+  );
+}

--- a/packages/media-server-mcp/src/resources/radarr-resources.ts
+++ b/packages/media-server-mcp/src/resources/radarr-resources.ts
@@ -1,0 +1,58 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { ResourceTemplate } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { RadarrConfig } from "@wyattjoh/radarr";
+import * as radarrClient from "@wyattjoh/radarr";
+
+export function createRadarrResources(
+  server: McpServer,
+  config: Readonly<RadarrConfig>,
+): void {
+  // Static resource: config://radarr
+  server.registerResource(
+    "radarr-config",
+    "config://radarr",
+    {
+      description:
+        "Radarr configuration including quality profiles and root folders",
+      mimeType: "application/json",
+    },
+    async (uri) => {
+      const [qualityProfiles, rootFolders] = await Promise.all([
+        radarrClient.getQualityProfiles(config),
+        radarrClient.getRootFolders(config),
+      ]);
+
+      return {
+        contents: [{
+          uri: uri.href,
+          text: JSON.stringify({ qualityProfiles, rootFolders }),
+          mimeType: "application/json",
+        }],
+      };
+    },
+  );
+
+  // Templated resource: radarr://movies/{movieId}
+  server.registerResource(
+    "radarr-movie",
+    new ResourceTemplate("radarr://movies/{movieId}", { list: undefined }),
+    {
+      description: "Details for a specific movie in Radarr",
+      mimeType: "application/json",
+    },
+    async (uri, { movieId }) => {
+      const movie = await radarrClient.getMovie(
+        config,
+        Number(movieId),
+      );
+
+      return {
+        contents: [{
+          uri: uri.href,
+          text: JSON.stringify(movie),
+          mimeType: "application/json",
+        }],
+      };
+    },
+  );
+}

--- a/packages/media-server-mcp/src/resources/sonarr-resources.ts
+++ b/packages/media-server-mcp/src/resources/sonarr-resources.ts
@@ -1,0 +1,58 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { ResourceTemplate } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { SonarrConfig } from "@wyattjoh/sonarr";
+import * as sonarrClient from "@wyattjoh/sonarr";
+
+export function createSonarrResources(
+  server: McpServer,
+  config: Readonly<SonarrConfig>,
+): void {
+  // Static resource: config://sonarr
+  server.registerResource(
+    "sonarr-config",
+    "config://sonarr",
+    {
+      description:
+        "Sonarr configuration including quality profiles and root folders",
+      mimeType: "application/json",
+    },
+    async (uri) => {
+      const [qualityProfiles, rootFolders] = await Promise.all([
+        sonarrClient.getQualityProfiles(config),
+        sonarrClient.getRootFolders(config),
+      ]);
+
+      return {
+        contents: [{
+          uri: uri.href,
+          text: JSON.stringify({ qualityProfiles, rootFolders }),
+          mimeType: "application/json",
+        }],
+      };
+    },
+  );
+
+  // Templated resource: sonarr://series/{seriesId}
+  server.registerResource(
+    "sonarr-series",
+    new ResourceTemplate("sonarr://series/{seriesId}", { list: undefined }),
+    {
+      description: "Details for a specific series in Sonarr",
+      mimeType: "application/json",
+    },
+    async (uri, { seriesId }) => {
+      const series = await sonarrClient.getSeriesById(
+        config,
+        Number(seriesId),
+      );
+
+      return {
+        contents: [{
+          uri: uri.href,
+          text: JSON.stringify(series),
+          mimeType: "application/json",
+        }],
+      };
+    },
+  );
+}

--- a/packages/media-server-mcp/src/resources/tmdb-resources.ts
+++ b/packages/media-server-mcp/src/resources/tmdb-resources.ts
@@ -1,0 +1,72 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { TMDBConfig } from "@wyattjoh/tmdb";
+import * as tmdbClient from "@wyattjoh/tmdb";
+
+export function createTMDBResources(
+  server: McpServer,
+  config: Readonly<TMDBConfig>,
+): void {
+  // Static resource: config://tmdb
+  server.registerResource(
+    "tmdb-config",
+    "config://tmdb",
+    {
+      description:
+        "TMDB API configuration including image base URLs and supported sizes",
+      mimeType: "application/json",
+    },
+    async (uri) => {
+      const configuration = await tmdbClient.getConfiguration(config);
+
+      return {
+        contents: [{
+          uri: uri.href,
+          text: JSON.stringify(configuration),
+          mimeType: "application/json",
+        }],
+      };
+    },
+  );
+
+  // Static resource: tmdb://genres/movies
+  server.registerResource(
+    "tmdb-genres-movies",
+    "tmdb://genres/movies",
+    {
+      description: "List of movie genres available on TMDB",
+      mimeType: "application/json",
+    },
+    async (uri) => {
+      const genres = await tmdbClient.getMovieGenres(config);
+
+      return {
+        contents: [{
+          uri: uri.href,
+          text: JSON.stringify(genres),
+          mimeType: "application/json",
+        }],
+      };
+    },
+  );
+
+  // Static resource: tmdb://genres/tv
+  server.registerResource(
+    "tmdb-genres-tv",
+    "tmdb://genres/tv",
+    {
+      description: "List of TV show genres available on TMDB",
+      mimeType: "application/json",
+    },
+    async (uri) => {
+      const genres = await tmdbClient.getTVGenres(config);
+
+      return {
+        contents: [{
+          uri: uri.href,
+          text: JSON.stringify(genres),
+          mimeType: "application/json",
+        }],
+      };
+    },
+  );
+}

--- a/packages/media-server-mcp/src/tools/plex-tools.ts
+++ b/packages/media-server-mcp/src/tools/plex-tools.ts
@@ -30,6 +30,7 @@ export function createPlexTools(
         description:
           "Get Plex server capabilities, version, and system information",
         inputSchema: {},
+        outputSchema: z.record(z.string(), z.unknown()),
         annotations: { readOnlyHint: true, openWorldHint: false },
       },
       wrapToolHandler("plex_get_capabilities", async () => {
@@ -39,6 +40,7 @@ export function createPlexTools(
             type: "text",
             text: JSON.stringify(result, null, 2),
           }],
+          structuredContent: result as unknown as Record<string, unknown>,
         };
       }),
     );
@@ -52,6 +54,7 @@ export function createPlexTools(
         title: "Get Plex media libraries",
         description: "List all media libraries available on the Plex server",
         inputSchema: {},
+        outputSchema: z.record(z.string(), z.unknown()),
         annotations: { readOnlyHint: true, openWorldHint: false },
       },
       wrapToolHandler("plex_get_libraries", async () => {
@@ -61,6 +64,7 @@ export function createPlexTools(
             type: "text",
             text: JSON.stringify(result, null, 2),
           }],
+          structuredContent: result as unknown as Record<string, unknown>,
         };
       }),
     );
@@ -85,6 +89,7 @@ export function createPlexTools(
             "Filter by content types. If not provided, searches all types",
           ),
         },
+        outputSchema: z.record(z.string(), z.unknown()),
         annotations: { readOnlyHint: true, openWorldHint: false },
       },
       wrapToolHandler("plex_search", async (args) => {
@@ -99,6 +104,7 @@ export function createPlexTools(
             type: "text",
             text: JSON.stringify(result, null, 2),
           }],
+          structuredContent: result as unknown as Record<string, unknown>,
         };
       }),
     );
@@ -117,6 +123,7 @@ export function createPlexTools(
             "The rating key (unique identifier) of the media item",
           ),
         },
+        outputSchema: z.record(z.string(), z.unknown()),
         annotations: { readOnlyHint: true, openWorldHint: false },
       },
       wrapToolHandler("plex_get_metadata", async (args) => {
@@ -126,6 +133,7 @@ export function createPlexTools(
             type: "text",
             text: JSON.stringify(result, null, 2),
           }],
+          structuredContent: result as unknown as Record<string, unknown>,
         };
       }),
     );
@@ -144,15 +152,20 @@ export function createPlexTools(
             "The library key (section ID) to refresh",
           ),
         },
+        outputSchema: { message: z.string() },
         annotations: { idempotentHint: true, openWorldHint: false },
       },
       wrapToolHandler("plex_refresh_library", async (args) => {
         await plexClient.refreshLibrary(config, args.key);
+        const result = {
+          message: `Library refresh initiated for section ${args.key}`,
+        };
         return {
           content: [{
             type: "text",
-            text: `Library refresh initiated for section ${args.key}`,
+            text: result.message,
           }],
+          structuredContent: result,
         };
       }),
     );
@@ -190,6 +203,7 @@ export function createPlexTools(
             "Number of items per page (default: 200). Use start for pagination.",
           ),
         },
+        outputSchema: z.record(z.string(), z.unknown()),
         annotations: { readOnlyHint: true, openWorldHint: false },
       },
       wrapToolHandler("plex_get_library_items", async (args) => {
@@ -207,6 +221,7 @@ export function createPlexTools(
             type: "text",
             text: JSON.stringify(result, slimReplacer, 2),
           }],
+          structuredContent: result as unknown as Record<string, unknown>,
         };
       }),
     );
@@ -228,6 +243,7 @@ export function createPlexTools(
             "Number of collections per page (default: 100). Use start for pagination.",
           ),
         },
+        outputSchema: z.record(z.string(), z.unknown()),
         annotations: { readOnlyHint: true, openWorldHint: false },
       },
       wrapToolHandler("plex_get_collections", async (args) => {
@@ -240,6 +256,7 @@ export function createPlexTools(
             type: "text",
             text: JSON.stringify(result, slimReplacer, 2),
           }],
+          structuredContent: result as unknown as Record<string, unknown>,
         };
       }),
     );
@@ -257,6 +274,7 @@ export function createPlexTools(
             "The collection rating key/ID",
           ),
         },
+        outputSchema: z.record(z.string(), z.unknown()),
         annotations: { readOnlyHint: true, openWorldHint: false },
       },
       wrapToolHandler("plex_get_collection_items", async (args) => {
@@ -269,6 +287,7 @@ export function createPlexTools(
             type: "text",
             text: JSON.stringify(result, slimReplacer, 2),
           }],
+          structuredContent: result as unknown as Record<string, unknown>,
         };
       }),
     );
@@ -289,6 +308,7 @@ export function createPlexTools(
             "Rating keys of items to add to the collection",
           ),
         },
+        outputSchema: z.record(z.string(), z.unknown()),
         annotations: { openWorldHint: false },
       },
       wrapToolHandler("plex_create_collection", async (args) => {
@@ -303,6 +323,7 @@ export function createPlexTools(
             type: "text",
             text: JSON.stringify(result, null, 2),
           }],
+          structuredContent: result as unknown as Record<string, unknown>,
         };
       }),
     );
@@ -323,6 +344,7 @@ export function createPlexTools(
             "Rating keys of items to add to the collection",
           ),
         },
+        outputSchema: { message: z.string() },
         annotations: { openWorldHint: false },
       },
       wrapToolHandler("plex_add_to_collection", async (args) => {
@@ -331,12 +353,16 @@ export function createPlexTools(
           args.collectionId,
           args.ratingKeys,
         );
+        const result = {
+          message:
+            `Successfully added ${args.ratingKeys.length} item(s) to collection ${args.collectionId}`,
+        };
         return {
           content: [{
             type: "text",
-            text:
-              `Successfully added ${args.ratingKeys.length} item(s) to collection ${args.collectionId}`,
+            text: result.message,
           }],
+          structuredContent: result,
         };
       }),
     );
@@ -357,6 +383,7 @@ export function createPlexTools(
             "Rating keys of items to remove",
           ),
         },
+        outputSchema: { message: z.string() },
         annotations: { destructiveHint: true, openWorldHint: false },
       },
       wrapToolHandler("plex_remove_from_collection", async (args) => {
@@ -367,12 +394,16 @@ export function createPlexTools(
             ratingKey,
           );
         }
+        const result = {
+          message:
+            `Removed ${args.ratingKeys.length} item(s) from collection ${args.collectionId}`,
+        };
         return {
           content: [{
             type: "text",
-            text:
-              `Removed ${args.ratingKeys.length} item(s) from collection ${args.collectionId}`,
+            text: result.message,
           }],
+          structuredContent: result,
         };
       }),
     );
@@ -390,15 +421,20 @@ export function createPlexTools(
             "The collection rating key/ID to delete",
           ),
         },
+        outputSchema: { message: z.string() },
         annotations: { destructiveHint: true, openWorldHint: false },
       },
       wrapToolHandler("plex_delete_collection", async (args) => {
         await plexClient.deleteCollection(config, args.collectionId);
+        const result = {
+          message: `Successfully deleted collection ${args.collectionId}`,
+        };
         return {
           content: [{
             type: "text",
-            text: `Successfully deleted collection ${args.collectionId}`,
+            text: result.message,
           }],
+          structuredContent: result,
         };
       }),
     );

--- a/packages/media-server-mcp/src/tools/plex-tools.ts
+++ b/packages/media-server-mcp/src/tools/plex-tools.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 import type { PlexConfig } from "@wyattjoh/plex";
 import * as plexClient from "@wyattjoh/plex";
 import { SearchType } from "@wyattjoh/plex";
+import { wrapToolHandler } from "./tool-wrapper.ts";
 
 const SLIM_OMIT_KEYS = new Set([
   "Media",
@@ -29,27 +30,17 @@ export function createPlexTools(
         description:
           "Get Plex server capabilities, version, and system information",
         inputSchema: {},
+        annotations: { readOnlyHint: true, openWorldHint: false },
       },
-      async () => {
-        try {
-          const result = await plexClient.getCapabilities(config);
-          return {
-            content: [{
-              type: "text",
-              text: JSON.stringify(result, null, 2),
-            }],
-          };
-        } catch (error) {
-          return {
-            content: [{
-              type: "text",
-              text: `Error: ${
-                error instanceof Error ? error.message : String(error)
-              }`,
-            }],
-          };
-        }
-      },
+      wrapToolHandler("plex_get_capabilities", async () => {
+        const result = await plexClient.getCapabilities(config);
+        return {
+          content: [{
+            type: "text",
+            text: JSON.stringify(result, null, 2),
+          }],
+        };
+      }),
     );
   }
 
@@ -61,27 +52,17 @@ export function createPlexTools(
         title: "Get Plex media libraries",
         description: "List all media libraries available on the Plex server",
         inputSchema: {},
+        annotations: { readOnlyHint: true, openWorldHint: false },
       },
-      async () => {
-        try {
-          const result = await plexClient.getLibraries(config);
-          return {
-            content: [{
-              type: "text",
-              text: JSON.stringify(result, null, 2),
-            }],
-          };
-        } catch (error) {
-          return {
-            content: [{
-              type: "text",
-              text: `Error: ${
-                error instanceof Error ? error.message : String(error)
-              }`,
-            }],
-          };
-        }
-      },
+      wrapToolHandler("plex_get_libraries", async () => {
+        const result = await plexClient.getLibraries(config);
+        return {
+          content: [{
+            type: "text",
+            text: JSON.stringify(result, null, 2),
+          }],
+        };
+      }),
     );
   }
 
@@ -104,32 +85,22 @@ export function createPlexTools(
             "Filter by content types. If not provided, searches all types",
           ),
         },
+        annotations: { readOnlyHint: true, openWorldHint: false },
       },
-      async (args) => {
-        try {
-          const result = await plexClient.search(
-            config,
-            args.query,
-            args.limit,
-            args.searchTypes,
-          );
-          return {
-            content: [{
-              type: "text",
-              text: JSON.stringify(result, null, 2),
-            }],
-          };
-        } catch (error) {
-          return {
-            content: [{
-              type: "text",
-              text: `Error: ${
-                error instanceof Error ? error.message : String(error)
-              }`,
-            }],
-          };
-        }
-      },
+      wrapToolHandler("plex_search", async (args) => {
+        const result = await plexClient.search(
+          config,
+          args.query,
+          args.limit,
+          args.searchTypes,
+        );
+        return {
+          content: [{
+            type: "text",
+            text: JSON.stringify(result, null, 2),
+          }],
+        };
+      }),
     );
   }
 
@@ -146,27 +117,17 @@ export function createPlexTools(
             "The rating key (unique identifier) of the media item",
           ),
         },
+        annotations: { readOnlyHint: true, openWorldHint: false },
       },
-      async (args) => {
-        try {
-          const result = await plexClient.getMetadata(config, args.ratingKey);
-          return {
-            content: [{
-              type: "text",
-              text: JSON.stringify(result, null, 2),
-            }],
-          };
-        } catch (error) {
-          return {
-            content: [{
-              type: "text",
-              text: `Error: ${
-                error instanceof Error ? error.message : String(error)
-              }`,
-            }],
-          };
-        }
-      },
+      wrapToolHandler("plex_get_metadata", async (args) => {
+        const result = await plexClient.getMetadata(config, args.ratingKey);
+        return {
+          content: [{
+            type: "text",
+            text: JSON.stringify(result, null, 2),
+          }],
+        };
+      }),
     );
   }
 
@@ -183,27 +144,17 @@ export function createPlexTools(
             "The library key (section ID) to refresh",
           ),
         },
+        annotations: { idempotentHint: true, openWorldHint: false },
       },
-      async (args) => {
-        try {
-          await plexClient.refreshLibrary(config, args.key);
-          return {
-            content: [{
-              type: "text",
-              text: `Library refresh initiated for section ${args.key}`,
-            }],
-          };
-        } catch (error) {
-          return {
-            content: [{
-              type: "text",
-              text: `Error: ${
-                error instanceof Error ? error.message : String(error)
-              }`,
-            }],
-          };
-        }
-      },
+      wrapToolHandler("plex_refresh_library", async (args) => {
+        await plexClient.refreshLibrary(config, args.key);
+        return {
+          content: [{
+            type: "text",
+            text: `Library refresh initiated for section ${args.key}`,
+          }],
+        };
+      }),
     );
   }
 
@@ -239,35 +190,25 @@ export function createPlexTools(
             "Number of items per page (default: 200). Use start for pagination.",
           ),
         },
+        annotations: { readOnlyHint: true, openWorldHint: false },
       },
-      async (args) => {
-        try {
-          const result = await plexClient.getLibraryItems(config, args.key, {
-            type: args.type,
-            studio: args.studio,
-            genre: args.genre,
-            year: args.year,
-            sort: args.sort,
-            start: args.start,
-            size: args.size,
-          });
-          return {
-            content: [{
-              type: "text",
-              text: JSON.stringify(result, slimReplacer, 2),
-            }],
-          };
-        } catch (error) {
-          return {
-            content: [{
-              type: "text",
-              text: `Error: ${
-                error instanceof Error ? error.message : String(error)
-              }`,
-            }],
-          };
-        }
-      },
+      wrapToolHandler("plex_get_library_items", async (args) => {
+        const result = await plexClient.getLibraryItems(config, args.key, {
+          type: args.type,
+          studio: args.studio,
+          genre: args.genre,
+          year: args.year,
+          sort: args.sort,
+          start: args.start,
+          size: args.size,
+        });
+        return {
+          content: [{
+            type: "text",
+            text: JSON.stringify(result, slimReplacer, 2),
+          }],
+        };
+      }),
     );
   }
 
@@ -287,30 +228,20 @@ export function createPlexTools(
             "Number of collections per page (default: 100). Use start for pagination.",
           ),
         },
+        annotations: { readOnlyHint: true, openWorldHint: false },
       },
-      async (args) => {
-        try {
-          const result = await plexClient.getCollections(config, args.key, {
-            ...(args.start !== undefined && { start: args.start }),
-            size: args.size,
-          });
-          return {
-            content: [{
-              type: "text",
-              text: JSON.stringify(result, slimReplacer, 2),
-            }],
-          };
-        } catch (error) {
-          return {
-            content: [{
-              type: "text",
-              text: `Error: ${
-                error instanceof Error ? error.message : String(error)
-              }`,
-            }],
-          };
-        }
-      },
+      wrapToolHandler("plex_get_collections", async (args) => {
+        const result = await plexClient.getCollections(config, args.key, {
+          ...(args.start !== undefined && { start: args.start }),
+          size: args.size,
+        });
+        return {
+          content: [{
+            type: "text",
+            text: JSON.stringify(result, slimReplacer, 2),
+          }],
+        };
+      }),
     );
   }
 
@@ -326,30 +257,20 @@ export function createPlexTools(
             "The collection rating key/ID",
           ),
         },
+        annotations: { readOnlyHint: true, openWorldHint: false },
       },
-      async (args) => {
-        try {
-          const result = await plexClient.getCollectionItems(
-            config,
-            args.collectionId,
-          );
-          return {
-            content: [{
-              type: "text",
-              text: JSON.stringify(result, slimReplacer, 2),
-            }],
-          };
-        } catch (error) {
-          return {
-            content: [{
-              type: "text",
-              text: `Error: ${
-                error instanceof Error ? error.message : String(error)
-              }`,
-            }],
-          };
-        }
-      },
+      wrapToolHandler("plex_get_collection_items", async (args) => {
+        const result = await plexClient.getCollectionItems(
+          config,
+          args.collectionId,
+        );
+        return {
+          content: [{
+            type: "text",
+            text: JSON.stringify(result, slimReplacer, 2),
+          }],
+        };
+      }),
     );
   }
 
@@ -368,32 +289,22 @@ export function createPlexTools(
             "Rating keys of items to add to the collection",
           ),
         },
+        annotations: { openWorldHint: false },
       },
-      async (args) => {
-        try {
-          const result = await plexClient.createCollection(
-            config,
-            args.sectionKey,
-            args.title,
-            args.ratingKeys,
-          );
-          return {
-            content: [{
-              type: "text",
-              text: JSON.stringify(result, null, 2),
-            }],
-          };
-        } catch (error) {
-          return {
-            content: [{
-              type: "text",
-              text: `Error: ${
-                error instanceof Error ? error.message : String(error)
-              }`,
-            }],
-          };
-        }
-      },
+      wrapToolHandler("plex_create_collection", async (args) => {
+        const result = await plexClient.createCollection(
+          config,
+          args.sectionKey,
+          args.title,
+          args.ratingKeys,
+        );
+        return {
+          content: [{
+            type: "text",
+            text: JSON.stringify(result, null, 2),
+          }],
+        };
+      }),
     );
   }
 
@@ -412,32 +323,22 @@ export function createPlexTools(
             "Rating keys of items to add to the collection",
           ),
         },
+        annotations: { openWorldHint: false },
       },
-      async (args) => {
-        try {
-          await plexClient.addToCollection(
-            config,
-            args.collectionId,
-            args.ratingKeys,
-          );
-          return {
-            content: [{
-              type: "text",
-              text:
-                `Successfully added ${args.ratingKeys.length} item(s) to collection ${args.collectionId}`,
-            }],
-          };
-        } catch (error) {
-          return {
-            content: [{
-              type: "text",
-              text: `Error: ${
-                error instanceof Error ? error.message : String(error)
-              }`,
-            }],
-          };
-        }
-      },
+      wrapToolHandler("plex_add_to_collection", async (args) => {
+        await plexClient.addToCollection(
+          config,
+          args.collectionId,
+          args.ratingKeys,
+        );
+        return {
+          content: [{
+            type: "text",
+            text:
+              `Successfully added ${args.ratingKeys.length} item(s) to collection ${args.collectionId}`,
+          }],
+        };
+      }),
     );
   }
 
@@ -456,34 +357,24 @@ export function createPlexTools(
             "Rating keys of items to remove",
           ),
         },
+        annotations: { destructiveHint: true, openWorldHint: false },
       },
-      async (args) => {
-        try {
-          for (const ratingKey of args.ratingKeys) {
-            await plexClient.removeFromCollection(
-              config,
-              args.collectionId,
-              ratingKey,
-            );
-          }
-          return {
-            content: [{
-              type: "text",
-              text:
-                `Removed ${args.ratingKeys.length} item(s) from collection ${args.collectionId}`,
-            }],
-          };
-        } catch (error) {
-          return {
-            content: [{
-              type: "text",
-              text: `Error: ${
-                error instanceof Error ? error.message : String(error)
-              }`,
-            }],
-          };
+      wrapToolHandler("plex_remove_from_collection", async (args) => {
+        for (const ratingKey of args.ratingKeys) {
+          await plexClient.removeFromCollection(
+            config,
+            args.collectionId,
+            ratingKey,
+          );
         }
-      },
+        return {
+          content: [{
+            type: "text",
+            text:
+              `Removed ${args.ratingKeys.length} item(s) from collection ${args.collectionId}`,
+          }],
+        };
+      }),
     );
   }
 
@@ -499,27 +390,17 @@ export function createPlexTools(
             "The collection rating key/ID to delete",
           ),
         },
+        annotations: { destructiveHint: true, openWorldHint: false },
       },
-      async (args) => {
-        try {
-          await plexClient.deleteCollection(config, args.collectionId);
-          return {
-            content: [{
-              type: "text",
-              text: `Successfully deleted collection ${args.collectionId}`,
-            }],
-          };
-        } catch (error) {
-          return {
-            content: [{
-              type: "text",
-              text: `Error: ${
-                error instanceof Error ? error.message : String(error)
-              }`,
-            }],
-          };
-        }
-      },
+      wrapToolHandler("plex_delete_collection", async (args) => {
+        await plexClient.deleteCollection(config, args.collectionId);
+        return {
+          content: [{
+            type: "text",
+            text: `Successfully deleted collection ${args.collectionId}`,
+          }],
+        };
+      }),
     );
   }
 }

--- a/packages/media-server-mcp/src/tools/radarr-tools.ts
+++ b/packages/media-server-mcp/src/tools/radarr-tools.ts
@@ -317,6 +317,7 @@ export function createRadarrTools(
               text:
                 "Error: Provide either 'id' (Radarr ID) or 'tmdbId', but not both",
             }],
+            isError: true,
           };
         }
 
@@ -341,6 +342,7 @@ export function createRadarrTools(
                   : `TMDB ID ${args.tmdbId}`
               }`,
             }],
+            isError: true,
           };
         }
 

--- a/packages/media-server-mcp/src/tools/radarr-tools.ts
+++ b/packages/media-server-mcp/src/tools/radarr-tools.ts
@@ -25,6 +25,13 @@ export function createRadarrTools(
             "Number of results to skip (for pagination)",
           ),
         },
+        outputSchema: {
+          data: z.array(z.record(z.string(), z.unknown())),
+          total: z.number(),
+          returned: z.number(),
+          skip: z.number(),
+          limit: z.number().optional(),
+        },
         annotations: { readOnlyHint: true, openWorldHint: false },
       },
       wrapToolHandler("radarr_search_movie", async (args) => {
@@ -39,6 +46,7 @@ export function createRadarrTools(
             type: "text",
             text: JSON.stringify(results, null, 2),
           }],
+          structuredContent: results as unknown as Record<string, unknown>,
         };
       }),
     );
@@ -76,6 +84,7 @@ export function createRadarrTools(
             "Tag IDs to apply to the movie",
           ),
         },
+        outputSchema: z.record(z.string(), z.unknown()),
         annotations: { openWorldHint: false },
       },
       wrapToolHandler("radarr_add_movie", async (args) => {
@@ -91,6 +100,7 @@ export function createRadarrTools(
             type: "text",
             text: JSON.stringify(result, null, 2),
           }],
+          structuredContent: result as unknown as Record<string, unknown>,
         };
       }),
     );
@@ -112,6 +122,7 @@ export function createRadarrTools(
             "Whether to add import exclusion",
           ),
         },
+        outputSchema: { message: z.string() },
         annotations: { destructiveHint: true, openWorldHint: false },
       },
       wrapToolHandler("radarr_delete_movie", async (args) => {
@@ -121,11 +132,13 @@ export function createRadarrTools(
           args.deleteFiles,
           args.addImportExclusion,
         );
+        const result = { message: `Movie ${args.id} deleted successfully` };
         return {
           content: [{
             type: "text",
-            text: `Movie ${args.id} deleted successfully`,
+            text: result.message,
           }],
+          structuredContent: result,
         };
       }),
     );
@@ -141,15 +154,20 @@ export function createRadarrTools(
         inputSchema: {
           id: z.number().describe("Movie ID in Radarr"),
         },
+        outputSchema: { message: z.string() },
         annotations: { idempotentHint: true, openWorldHint: false },
       },
       wrapToolHandler("radarr_refresh_movie", async (args) => {
         await radarrClient.refreshMovie(config, args.id);
+        const result = {
+          message: `Movie ${args.id} refresh initiated successfully`,
+        };
         return {
           content: [{
             type: "text",
-            text: `Movie ${args.id} refresh initiated successfully`,
+            text: result.message,
           }],
+          structuredContent: result,
         };
       }),
     );
@@ -165,15 +183,21 @@ export function createRadarrTools(
         inputSchema: {
           id: z.number().describe("Movie ID in Radarr"),
         },
+        outputSchema: { message: z.string() },
         annotations: { idempotentHint: true, openWorldHint: false },
       },
       wrapToolHandler("radarr_search_movie_releases", async (args) => {
         await radarrClient.searchMovieReleases(config, args.id);
+        const result = {
+          message:
+            `Search for movie ${args.id} releases initiated successfully`,
+        };
         return {
           content: [{
             type: "text",
-            text: `Search for movie ${args.id} releases initiated successfully`,
+            text: result.message,
           }],
+          structuredContent: result,
         };
       }),
     );
@@ -240,6 +264,13 @@ export function createRadarrTools(
             direction: z.enum(["asc", "desc"]).describe("Sort direction"),
           }).optional().describe("Sort options for movies"),
         },
+        outputSchema: {
+          data: z.array(z.record(z.string(), z.unknown())),
+          total: z.number(),
+          returned: z.number(),
+          skip: z.number(),
+          limit: z.number().optional(),
+        },
         annotations: { readOnlyHint: true, openWorldHint: false },
       },
       wrapToolHandler("radarr_get_movies", async (args) => {
@@ -255,6 +286,7 @@ export function createRadarrTools(
             type: "text",
             text: JSON.stringify(results, null, 2),
           }],
+          structuredContent: results as unknown as Record<string, unknown>,
         };
       }),
     );
@@ -273,6 +305,7 @@ export function createRadarrTools(
             "The Movie Database (TMDB) ID",
           ),
         },
+        outputSchema: z.record(z.string(), z.unknown()),
         annotations: { readOnlyHint: true, openWorldHint: false },
       },
       wrapToolHandler("radarr_get_movie", async (args) => {
@@ -316,6 +349,7 @@ export function createRadarrTools(
             type: "text",
             text: JSON.stringify(result, null, 2),
           }],
+          structuredContent: result as unknown as Record<string, unknown>,
         };
       }),
     );
@@ -331,6 +365,10 @@ export function createRadarrTools(
         description:
           "Get Radarr configuration including quality profiles, and root folders",
         inputSchema: {},
+        outputSchema: {
+          qualityProfiles: z.array(z.record(z.string(), z.unknown())),
+          rootFolders: z.array(z.record(z.string(), z.unknown())),
+        },
         annotations: { readOnlyHint: true, openWorldHint: false },
       },
       wrapToolHandler("radarr_get_configuration", async () => {
@@ -339,14 +377,18 @@ export function createRadarrTools(
           radarrClient.getRootFolders(config),
         ]);
         const result = {
-          qualityProfiles,
-          rootFolders,
+          qualityProfiles: qualityProfiles as unknown as Record<
+            string,
+            unknown
+          >[],
+          rootFolders: rootFolders as unknown as Record<string, unknown>[],
         };
         return {
           content: [{
             type: "text",
             text: JSON.stringify(result, null, 2),
           }],
+          structuredContent: result,
         };
       }),
     );
@@ -377,6 +419,7 @@ export function createRadarrTools(
           ]).optional().describe("Minimum availability for monitoring"),
           tags: z.array(z.number()).optional().describe("Tag IDs"),
         },
+        outputSchema: z.record(z.string(), z.unknown()),
         annotations: { idempotentHint: true, openWorldHint: false },
       },
       wrapToolHandler("radarr_update_movie", async (args) => {
@@ -401,6 +444,7 @@ export function createRadarrTools(
             type: "text",
             text: JSON.stringify(result, null, 2),
           }],
+          structuredContent: result as unknown as Record<string, unknown>,
         };
       }),
     );
@@ -414,15 +458,18 @@ export function createRadarrTools(
         title: "Refresh metadata for all movies in the library",
         description: "Refresh metadata for all movies in the library",
         inputSchema: {},
+        outputSchema: { message: z.string() },
         annotations: { idempotentHint: true, openWorldHint: false },
       },
       wrapToolHandler("radarr_refresh_all_movies", async () => {
         await radarrClient.refreshAllMovies(config);
+        const result = { message: "Refresh all movies initiated successfully" };
         return {
           content: [{
             type: "text",
-            text: "Refresh all movies initiated successfully",
+            text: result.message,
           }],
+          structuredContent: result,
         };
       }),
     );
@@ -436,15 +483,18 @@ export function createRadarrTools(
         title: "Rescan all movie folders for new/missing files",
         description: "Rescan all movie folders for new/missing files",
         inputSchema: {},
+        outputSchema: { message: z.string() },
         annotations: { idempotentHint: true, openWorldHint: false },
       },
       wrapToolHandler("radarr_disk_scan", async () => {
         await radarrClient.diskScan(config);
+        const result = { message: "Disk scan initiated successfully" };
         return {
           content: [{
             type: "text",
-            text: "Disk scan initiated successfully",
+            text: result.message,
           }],
+          structuredContent: result,
         };
       }),
     );

--- a/packages/media-server-mcp/src/tools/radarr-tools.ts
+++ b/packages/media-server-mcp/src/tools/radarr-tools.ts
@@ -2,6 +2,7 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import type { RadarrConfig, RadarrMovie } from "@wyattjoh/radarr";
 import * as radarrClient from "@wyattjoh/radarr";
+import { wrapToolHandler } from "./tool-wrapper.ts";
 
 export function createRadarrTools(
   server: McpServer,
@@ -24,32 +25,22 @@ export function createRadarrTools(
             "Number of results to skip (for pagination)",
           ),
         },
+        annotations: { readOnlyHint: true, openWorldHint: false },
       },
-      async (args) => {
-        try {
-          const results = await radarrClient.searchMovie(
-            config,
-            args.term,
-            args.limit,
-            args.skip,
-          );
-          return {
-            content: [{
-              type: "text",
-              text: JSON.stringify(results, null, 2),
-            }],
-          };
-        } catch (error) {
-          return {
-            content: [{
-              type: "text",
-              text: `Error: ${
-                error instanceof Error ? error.message : String(error)
-              }`,
-            }],
-          };
-        }
-      },
+      wrapToolHandler("radarr_search_movie", async (args) => {
+        const results = await radarrClient.searchMovie(
+          config,
+          args.term,
+          args.limit,
+          args.skip,
+        );
+        return {
+          content: [{
+            type: "text",
+            text: JSON.stringify(results, null, 2),
+          }],
+        };
+      }),
     );
   }
 
@@ -85,33 +76,23 @@ export function createRadarrTools(
             "Tag IDs to apply to the movie",
           ),
         },
+        annotations: { openWorldHint: false },
       },
-      async (args) => {
-        try {
-          const params = {
-            ...args,
-            tags: args.tags || undefined,
-            monitored: args.monitored ?? undefined,
-            searchForMovie: args.searchForMovie ?? undefined,
-          };
-          const result = await radarrClient.addMovie(config, params);
-          return {
-            content: [{
-              type: "text",
-              text: JSON.stringify(result, null, 2),
-            }],
-          };
-        } catch (error) {
-          return {
-            content: [{
-              type: "text",
-              text: `Error: ${
-                error instanceof Error ? error.message : String(error)
-              }`,
-            }],
-          };
-        }
-      },
+      wrapToolHandler("radarr_add_movie", async (args) => {
+        const params = {
+          ...args,
+          tags: args.tags || undefined,
+          monitored: args.monitored ?? undefined,
+          searchForMovie: args.searchForMovie ?? undefined,
+        };
+        const result = await radarrClient.addMovie(config, params);
+        return {
+          content: [{
+            type: "text",
+            text: JSON.stringify(result, null, 2),
+          }],
+        };
+      }),
     );
   }
 
@@ -131,32 +112,22 @@ export function createRadarrTools(
             "Whether to add import exclusion",
           ),
         },
+        annotations: { destructiveHint: true, openWorldHint: false },
       },
-      async (args) => {
-        try {
-          await radarrClient.deleteMovie(
-            config,
-            args.id,
-            args.deleteFiles,
-            args.addImportExclusion,
-          );
-          return {
-            content: [{
-              type: "text",
-              text: `Movie ${args.id} deleted successfully`,
-            }],
-          };
-        } catch (error) {
-          return {
-            content: [{
-              type: "text",
-              text: `Error: ${
-                error instanceof Error ? error.message : String(error)
-              }`,
-            }],
-          };
-        }
-      },
+      wrapToolHandler("radarr_delete_movie", async (args) => {
+        await radarrClient.deleteMovie(
+          config,
+          args.id,
+          args.deleteFiles,
+          args.addImportExclusion,
+        );
+        return {
+          content: [{
+            type: "text",
+            text: `Movie ${args.id} deleted successfully`,
+          }],
+        };
+      }),
     );
   }
 
@@ -170,27 +141,17 @@ export function createRadarrTools(
         inputSchema: {
           id: z.number().describe("Movie ID in Radarr"),
         },
+        annotations: { idempotentHint: true, openWorldHint: false },
       },
-      async (args) => {
-        try {
-          await radarrClient.refreshMovie(config, args.id);
-          return {
-            content: [{
-              type: "text",
-              text: `Movie ${args.id} refresh initiated successfully`,
-            }],
-          };
-        } catch (error) {
-          return {
-            content: [{
-              type: "text",
-              text: `Error: ${
-                error instanceof Error ? error.message : String(error)
-              }`,
-            }],
-          };
-        }
-      },
+      wrapToolHandler("radarr_refresh_movie", async (args) => {
+        await radarrClient.refreshMovie(config, args.id);
+        return {
+          content: [{
+            type: "text",
+            text: `Movie ${args.id} refresh initiated successfully`,
+          }],
+        };
+      }),
     );
   }
 
@@ -204,28 +165,17 @@ export function createRadarrTools(
         inputSchema: {
           id: z.number().describe("Movie ID in Radarr"),
         },
+        annotations: { idempotentHint: true, openWorldHint: false },
       },
-      async (args) => {
-        try {
-          await radarrClient.searchMovieReleases(config, args.id);
-          return {
-            content: [{
-              type: "text",
-              text:
-                `Search for movie ${args.id} releases initiated successfully`,
-            }],
-          };
-        } catch (error) {
-          return {
-            content: [{
-              type: "text",
-              text: `Error: ${
-                error instanceof Error ? error.message : String(error)
-              }`,
-            }],
-          };
-        }
-      },
+      wrapToolHandler("radarr_search_movie_releases", async (args) => {
+        await radarrClient.searchMovieReleases(config, args.id);
+        return {
+          content: [{
+            type: "text",
+            text: `Search for movie ${args.id} releases initiated successfully`,
+          }],
+        };
+      }),
     );
   }
 
@@ -290,33 +240,23 @@ export function createRadarrTools(
             direction: z.enum(["asc", "desc"]).describe("Sort direction"),
           }).optional().describe("Sort options for movies"),
         },
+        annotations: { readOnlyHint: true, openWorldHint: false },
       },
-      async (args) => {
-        try {
-          const results = await radarrClient.getMovies(
-            config,
-            args.limit,
-            args.skip,
-            args.filters,
-            args.sort,
-          );
-          return {
-            content: [{
-              type: "text",
-              text: JSON.stringify(results, null, 2),
-            }],
-          };
-        } catch (error) {
-          return {
-            content: [{
-              type: "text",
-              text: `Error: ${
-                error instanceof Error ? error.message : String(error)
-              }`,
-            }],
-          };
-        }
-      },
+      wrapToolHandler("radarr_get_movies", async (args) => {
+        const results = await radarrClient.getMovies(
+          config,
+          args.limit,
+          args.skip,
+          args.filters,
+          args.sort,
+        );
+        return {
+          content: [{
+            type: "text",
+            text: JSON.stringify(results, null, 2),
+          }],
+        };
+      }),
     );
   }
 
@@ -333,61 +273,51 @@ export function createRadarrTools(
             "The Movie Database (TMDB) ID",
           ),
         },
+        annotations: { readOnlyHint: true, openWorldHint: false },
       },
-      async (args) => {
-        try {
-          // Validate that exactly one identifier is provided
-          if ((args.id === undefined) === (args.tmdbId === undefined)) {
-            return {
-              content: [{
-                type: "text",
-                text:
-                  "Error: Provide either 'id' (Radarr ID) or 'tmdbId', but not both",
-              }],
-            };
-          }
-
-          let result;
-          if (args.id !== undefined) {
-            // Use Radarr ID
-            result = await radarrClient.getMovie(config, args.id);
-          } else if (args.tmdbId !== undefined) {
-            // Use TMDB ID
-            result = await radarrClient.getMovie(config, {
-              tmdbId: args.tmdbId,
-            });
-          }
-
-          if (!result) {
-            return {
-              content: [{
-                type: "text",
-                text: `Movie not found with ${
-                  args.id !== undefined
-                    ? `Radarr ID ${args.id}`
-                    : `TMDB ID ${args.tmdbId}`
-                }`,
-              }],
-            };
-          }
-
+      wrapToolHandler("radarr_get_movie", async (args) => {
+        // Validate that exactly one identifier is provided
+        if ((args.id === undefined) === (args.tmdbId === undefined)) {
           return {
             content: [{
               type: "text",
-              text: JSON.stringify(result, null, 2),
+              text:
+                "Error: Provide either 'id' (Radarr ID) or 'tmdbId', but not both",
             }],
           };
-        } catch (error) {
+        }
+
+        let result;
+        if (args.id !== undefined) {
+          // Use Radarr ID
+          result = await radarrClient.getMovie(config, args.id);
+        } else if (args.tmdbId !== undefined) {
+          // Use TMDB ID
+          result = await radarrClient.getMovie(config, {
+            tmdbId: args.tmdbId,
+          });
+        }
+
+        if (!result) {
           return {
             content: [{
               type: "text",
-              text: `Error: ${
-                error instanceof Error ? error.message : String(error)
+              text: `Movie not found with ${
+                args.id !== undefined
+                  ? `Radarr ID ${args.id}`
+                  : `TMDB ID ${args.tmdbId}`
               }`,
             }],
           };
         }
-      },
+
+        return {
+          content: [{
+            type: "text",
+            text: JSON.stringify(result, null, 2),
+          }],
+        };
+      }),
     );
   }
 
@@ -401,34 +331,24 @@ export function createRadarrTools(
         description:
           "Get Radarr configuration including quality profiles, and root folders",
         inputSchema: {},
+        annotations: { readOnlyHint: true, openWorldHint: false },
       },
-      async () => {
-        try {
-          const [qualityProfiles, rootFolders] = await Promise.all([
-            radarrClient.getQualityProfiles(config),
-            radarrClient.getRootFolders(config),
-          ]);
-          const result = {
-            qualityProfiles,
-            rootFolders,
-          };
-          return {
-            content: [{
-              type: "text",
-              text: JSON.stringify(result, null, 2),
-            }],
-          };
-        } catch (error) {
-          return {
-            content: [{
-              type: "text",
-              text: `Error: ${
-                error instanceof Error ? error.message : String(error)
-              }`,
-            }],
-          };
-        }
-      },
+      wrapToolHandler("radarr_get_configuration", async () => {
+        const [qualityProfiles, rootFolders] = await Promise.all([
+          radarrClient.getQualityProfiles(config),
+          radarrClient.getRootFolders(config),
+        ]);
+        const result = {
+          qualityProfiles,
+          rootFolders,
+        };
+        return {
+          content: [{
+            type: "text",
+            text: JSON.stringify(result, null, 2),
+          }],
+        };
+      }),
     );
   }
 
@@ -457,42 +377,32 @@ export function createRadarrTools(
           ]).optional().describe("Minimum availability for monitoring"),
           tags: z.array(z.number()).optional().describe("Tag IDs"),
         },
+        annotations: { idempotentHint: true, openWorldHint: false },
       },
-      async (args) => {
-        try {
-          // First get the current movie data
-          const currentMovie = await radarrClient.getMovie(config, args.id);
+      wrapToolHandler("radarr_update_movie", async (args) => {
+        // First get the current movie data
+        const currentMovie = await radarrClient.getMovie(config, args.id);
 
-          // Update only the specified fields
-          const updatedMovie = {
-            ...currentMovie,
-            ...(args.monitored !== undefined &&
-              { monitored: args.monitored }),
-            ...(args.qualityProfileId !== undefined &&
-              { qualityProfileId: args.qualityProfileId }),
-            ...(args.minimumAvailability !== undefined &&
-              { minimumAvailability: args.minimumAvailability }),
-            ...(args.tags !== undefined && { tags: args.tags }),
-          } as RadarrMovie;
+        // Update only the specified fields
+        const updatedMovie = {
+          ...currentMovie,
+          ...(args.monitored !== undefined &&
+            { monitored: args.monitored }),
+          ...(args.qualityProfileId !== undefined &&
+            { qualityProfileId: args.qualityProfileId }),
+          ...(args.minimumAvailability !== undefined &&
+            { minimumAvailability: args.minimumAvailability }),
+          ...(args.tags !== undefined && { tags: args.tags }),
+        } as RadarrMovie;
 
-          const result = await radarrClient.updateMovie(config, updatedMovie);
-          return {
-            content: [{
-              type: "text",
-              text: JSON.stringify(result, null, 2),
-            }],
-          };
-        } catch (error) {
-          return {
-            content: [{
-              type: "text",
-              text: `Error: ${
-                error instanceof Error ? error.message : String(error)
-              }`,
-            }],
-          };
-        }
-      },
+        const result = await radarrClient.updateMovie(config, updatedMovie);
+        return {
+          content: [{
+            type: "text",
+            text: JSON.stringify(result, null, 2),
+          }],
+        };
+      }),
     );
   }
 
@@ -504,27 +414,17 @@ export function createRadarrTools(
         title: "Refresh metadata for all movies in the library",
         description: "Refresh metadata for all movies in the library",
         inputSchema: {},
+        annotations: { idempotentHint: true, openWorldHint: false },
       },
-      async () => {
-        try {
-          await radarrClient.refreshAllMovies(config);
-          return {
-            content: [{
-              type: "text",
-              text: "Refresh all movies initiated successfully",
-            }],
-          };
-        } catch (error) {
-          return {
-            content: [{
-              type: "text",
-              text: `Error: ${
-                error instanceof Error ? error.message : String(error)
-              }`,
-            }],
-          };
-        }
-      },
+      wrapToolHandler("radarr_refresh_all_movies", async () => {
+        await radarrClient.refreshAllMovies(config);
+        return {
+          content: [{
+            type: "text",
+            text: "Refresh all movies initiated successfully",
+          }],
+        };
+      }),
     );
   }
 
@@ -536,27 +436,17 @@ export function createRadarrTools(
         title: "Rescan all movie folders for new/missing files",
         description: "Rescan all movie folders for new/missing files",
         inputSchema: {},
+        annotations: { idempotentHint: true, openWorldHint: false },
       },
-      async () => {
-        try {
-          await radarrClient.diskScan(config);
-          return {
-            content: [{
-              type: "text",
-              text: "Disk scan initiated successfully",
-            }],
-          };
-        } catch (error) {
-          return {
-            content: [{
-              type: "text",
-              text: `Error: ${
-                error instanceof Error ? error.message : String(error)
-              }`,
-            }],
-          };
-        }
-      },
+      wrapToolHandler("radarr_disk_scan", async () => {
+        await radarrClient.diskScan(config);
+        return {
+          content: [{
+            type: "text",
+            text: "Disk scan initiated successfully",
+          }],
+        };
+      }),
     );
   }
 }

--- a/packages/media-server-mcp/src/tools/sonarr-tools.ts
+++ b/packages/media-server-mcp/src/tools/sonarr-tools.ts
@@ -396,6 +396,7 @@ export function createSonarrTools(
               text:
                 "Error: Provide either 'id' (Sonarr ID) or 'tvdbId', but not both",
             }],
+            isError: true,
           };
         }
 
@@ -420,6 +421,7 @@ export function createSonarrTools(
                   : `TVDB ID ${args.tvdbId}`
               }`,
             }],
+            isError: true,
           };
         }
 

--- a/packages/media-server-mcp/src/tools/sonarr-tools.ts
+++ b/packages/media-server-mcp/src/tools/sonarr-tools.ts
@@ -25,6 +25,13 @@ export function createSonarrTools(
             "Number of results to skip (for pagination)",
           ),
         },
+        outputSchema: {
+          data: z.array(z.record(z.string(), z.unknown())),
+          total: z.number(),
+          returned: z.number(),
+          skip: z.number(),
+          limit: z.number().optional(),
+        },
         annotations: { readOnlyHint: true, openWorldHint: false },
       },
       wrapToolHandler("sonarr_search_series", async (args) => {
@@ -39,6 +46,7 @@ export function createSonarrTools(
             type: "text",
             text: JSON.stringify(results, null, 2),
           }],
+          structuredContent: results as unknown as Record<string, unknown>,
         };
       }),
     );
@@ -80,6 +88,7 @@ export function createSonarrTools(
           searchForMissingEpisodes: z.boolean().optional().default(false)
             .describe("Whether to search for missing episodes after adding"),
         },
+        outputSchema: z.record(z.string(), z.unknown()),
         annotations: { openWorldHint: false },
       },
       wrapToolHandler("sonarr_add_series", async (args) => {
@@ -105,6 +114,7 @@ export function createSonarrTools(
             type: "text",
             text: JSON.stringify(result, null, 2),
           }],
+          structuredContent: result as unknown as Record<string, unknown>,
         };
       }),
     );
@@ -126,6 +136,7 @@ export function createSonarrTools(
             "Whether to add import exclusion",
           ),
         },
+        outputSchema: { message: z.string() },
         annotations: { destructiveHint: true, openWorldHint: false },
       },
       wrapToolHandler("sonarr_delete_series", async (args) => {
@@ -135,11 +146,13 @@ export function createSonarrTools(
           args.deleteFiles,
           args.addImportExclusion,
         );
+        const result = { message: `Series ${args.id} deleted successfully` };
         return {
           content: [{
             type: "text",
-            text: `Series ${args.id} deleted successfully`,
+            text: result.message,
           }],
+          structuredContent: result,
         };
       }),
     );
@@ -160,6 +173,7 @@ export function createSonarrTools(
             "Whether to monitor or unmonitor the episodes",
           ),
         },
+        outputSchema: { message: z.string() },
         annotations: { idempotentHint: true, openWorldHint: false },
       },
       wrapToolHandler("sonarr_update_episode_monitoring", async (args) => {
@@ -168,12 +182,16 @@ export function createSonarrTools(
           args.episodeIds,
           args.monitored,
         );
+        const result = {
+          message:
+            `Episode monitoring updated for ${args.episodeIds.length} episodes`,
+        };
         return {
           content: [{
             type: "text",
-            text:
-              `Episode monitoring updated for ${args.episodeIds.length} episodes`,
+            text: result.message,
           }],
+          structuredContent: result,
         };
       }),
     );
@@ -189,15 +207,20 @@ export function createSonarrTools(
         inputSchema: {
           id: z.number().describe("Series ID in Sonarr"),
         },
+        outputSchema: { message: z.string() },
         annotations: { idempotentHint: true, openWorldHint: false },
       },
       wrapToolHandler("sonarr_refresh_series", async (args) => {
         await sonarrClient.refreshSeries(config, args.id);
+        const result = {
+          message: `Series ${args.id} refresh initiated successfully`,
+        };
         return {
           content: [{
             type: "text",
-            text: `Series ${args.id} refresh initiated successfully`,
+            text: result.message,
           }],
+          structuredContent: result,
         };
       }),
     );
@@ -213,16 +236,21 @@ export function createSonarrTools(
         inputSchema: {
           id: z.number().describe("Series ID in Sonarr"),
         },
+        outputSchema: { message: z.string() },
         annotations: { idempotentHint: true, openWorldHint: false },
       },
       wrapToolHandler("sonarr_search_series_episodes", async (args) => {
         await sonarrClient.searchSeriesEpisodes(config, args.id);
+        const result = {
+          message:
+            `Search for series ${args.id} episodes initiated successfully`,
+        };
         return {
           content: [{
             type: "text",
-            text:
-              `Search for series ${args.id} episodes initiated successfully`,
+            text: result.message,
           }],
+          structuredContent: result,
         };
       }),
     );
@@ -239,6 +267,7 @@ export function createSonarrTools(
           seriesId: z.number().describe("Series ID in Sonarr"),
           seasonNumber: z.number().describe("Season number to search"),
         },
+        outputSchema: { message: z.string() },
         annotations: { idempotentHint: true, openWorldHint: false },
       },
       wrapToolHandler("sonarr_search_season", async (args) => {
@@ -247,12 +276,16 @@ export function createSonarrTools(
           args.seriesId,
           args.seasonNumber,
         );
+        const result = {
+          message:
+            `Search for series ${args.seriesId} season ${args.seasonNumber} initiated successfully`,
+        };
         return {
           content: [{
             type: "text",
-            text:
-              `Search for series ${args.seriesId} season ${args.seasonNumber} initiated successfully`,
+            text: result.message,
           }],
+          structuredContent: result,
         };
       }),
     );
@@ -311,6 +344,13 @@ export function createSonarrTools(
             direction: z.enum(["asc", "desc"]).describe("Sort direction"),
           }).optional().describe("Sort options for series"),
         },
+        outputSchema: {
+          data: z.array(z.record(z.string(), z.unknown())),
+          total: z.number(),
+          returned: z.number(),
+          skip: z.number(),
+          limit: z.number().optional(),
+        },
         annotations: { readOnlyHint: true, openWorldHint: false },
       },
       wrapToolHandler("sonarr_get_series", async (args) => {
@@ -326,6 +366,7 @@ export function createSonarrTools(
             type: "text",
             text: JSON.stringify(results, null, 2),
           }],
+          structuredContent: results as unknown as Record<string, unknown>,
         };
       }),
     );
@@ -343,6 +384,7 @@ export function createSonarrTools(
           id: z.number().optional().describe("Series ID in Sonarr"),
           tvdbId: z.number().optional().describe("The TV Database (TVDB) ID"),
         },
+        outputSchema: z.record(z.string(), z.unknown()),
         annotations: { readOnlyHint: true, openWorldHint: false },
       },
       wrapToolHandler("sonarr_get_series_by_id", async (args) => {
@@ -386,6 +428,7 @@ export function createSonarrTools(
             type: "text",
             text: JSON.stringify(result, null, 2),
           }],
+          structuredContent: result as unknown as Record<string, unknown>,
         };
       }),
     );
@@ -410,6 +453,13 @@ export function createSonarrTools(
             "Number of results to skip (for pagination)",
           ),
         },
+        outputSchema: {
+          data: z.array(z.record(z.string(), z.unknown())),
+          total: z.number(),
+          returned: z.number(),
+          skip: z.number(),
+          limit: z.number().optional(),
+        },
         annotations: { readOnlyHint: true, openWorldHint: false },
       },
       wrapToolHandler("sonarr_get_episodes", async (args) => {
@@ -425,6 +475,7 @@ export function createSonarrTools(
             type: "text",
             text: JSON.stringify(results, null, 2),
           }],
+          structuredContent: results as unknown as Record<string, unknown>,
         };
       }),
     );
@@ -457,6 +508,13 @@ export function createSonarrTools(
             "Number of results to skip (for pagination)",
           ),
         },
+        outputSchema: {
+          data: z.array(z.record(z.string(), z.unknown())),
+          total: z.number(),
+          returned: z.number(),
+          skip: z.number(),
+          limit: z.number().optional(),
+        },
         annotations: { readOnlyHint: true, openWorldHint: false },
       },
       wrapToolHandler("sonarr_get_calendar", async (args) => {
@@ -474,6 +532,7 @@ export function createSonarrTools(
             type: "text",
             text: JSON.stringify(results, null, 2),
           }],
+          structuredContent: results as unknown as Record<string, unknown>,
         };
       }),
     );
@@ -494,6 +553,13 @@ export function createSonarrTools(
             "Number of results to skip (for pagination)",
           ),
         },
+        outputSchema: {
+          data: z.array(z.record(z.string(), z.unknown())),
+          total: z.number(),
+          returned: z.number(),
+          skip: z.number(),
+          limit: z.number().optional(),
+        },
         annotations: { readOnlyHint: true, openWorldHint: false },
       },
       wrapToolHandler("sonarr_get_queue", async (args) => {
@@ -507,6 +573,7 @@ export function createSonarrTools(
             type: "text",
             text: JSON.stringify(results, null, 2),
           }],
+          structuredContent: results as unknown as Record<string, unknown>,
         };
       }),
     );
@@ -522,6 +589,10 @@ export function createSonarrTools(
         description:
           "Get Sonarr configuration including quality profiles and root folders",
         inputSchema: {},
+        outputSchema: {
+          qualityProfiles: z.array(z.record(z.string(), z.unknown())),
+          rootFolders: z.array(z.record(z.string(), z.unknown())),
+        },
         annotations: { readOnlyHint: true, openWorldHint: false },
       },
       wrapToolHandler("sonarr_get_configuration", async () => {
@@ -529,18 +600,19 @@ export function createSonarrTools(
           sonarrClient.getQualityProfiles(config),
           sonarrClient.getRootFolders(config),
         ]);
+        const result = {
+          qualityProfiles: qualityProfiles as unknown as Record<
+            string,
+            unknown
+          >[],
+          rootFolders: rootFolders as unknown as Record<string, unknown>[],
+        };
         return {
           content: [{
             type: "text",
-            text: JSON.stringify(
-              {
-                qualityProfiles,
-                rootFolders,
-              },
-              null,
-              2,
-            ),
+            text: JSON.stringify(result, null, 2),
           }],
+          structuredContent: result,
         };
       }),
     );
@@ -554,6 +626,7 @@ export function createSonarrTools(
         title: "Get Sonarr system status",
         description: "Get Sonarr system status",
         inputSchema: {},
+        outputSchema: z.record(z.string(), z.unknown()),
         annotations: { readOnlyHint: true, openWorldHint: false },
       },
       wrapToolHandler("sonarr_get_system_status", async () => {
@@ -563,6 +636,7 @@ export function createSonarrTools(
             type: "text",
             text: JSON.stringify(result, null, 2),
           }],
+          structuredContent: result as unknown as Record<string, unknown>,
         };
       }),
     );
@@ -576,15 +650,22 @@ export function createSonarrTools(
         title: "Get Sonarr health check results",
         description: "Get Sonarr health check results",
         inputSchema: {},
+        outputSchema: {
+          data: z.array(z.record(z.string(), z.unknown())),
+        },
         annotations: { readOnlyHint: true, openWorldHint: false },
       },
       wrapToolHandler("sonarr_get_health", async () => {
         const results = await sonarrClient.getHealth(config);
+        const result = {
+          data: results as unknown as Record<string, unknown>[],
+        };
         return {
           content: [{
             type: "text",
             text: JSON.stringify(results, null, 2),
           }],
+          structuredContent: result,
         };
       }),
     );
@@ -603,6 +684,7 @@ export function createSonarrTools(
             "Series object with updated fields",
           ),
         },
+        outputSchema: z.record(z.string(), z.unknown()),
         annotations: { idempotentHint: true, openWorldHint: false },
       },
       wrapToolHandler("sonarr_update_series", async (args) => {
@@ -613,6 +695,7 @@ export function createSonarrTools(
             type: "text",
             text: JSON.stringify(result, null, 2),
           }],
+          structuredContent: result as unknown as Record<string, unknown>,
         };
       }),
     );
@@ -628,6 +711,7 @@ export function createSonarrTools(
         inputSchema: {
           id: z.number().describe("Episode ID in Sonarr"),
         },
+        outputSchema: z.record(z.string(), z.unknown()),
         annotations: { readOnlyHint: true, openWorldHint: false },
       },
       wrapToolHandler("sonarr_get_episode", async (args) => {
@@ -637,6 +721,7 @@ export function createSonarrTools(
             type: "text",
             text: JSON.stringify(result, null, 2),
           }],
+          structuredContent: result as unknown as Record<string, unknown>,
         };
       }),
     );
@@ -650,15 +735,20 @@ export function createSonarrTools(
         title: "Refresh metadata for all series in the library",
         description: "Refresh metadata for all series in the library",
         inputSchema: {},
+        outputSchema: { message: z.string() },
         annotations: { idempotentHint: true, openWorldHint: false },
       },
       wrapToolHandler("sonarr_refresh_all_series", async () => {
         await sonarrClient.refreshAllSeries(config);
+        const result = {
+          message: "Refresh initiated for all series in the library",
+        };
         return {
           content: [{
             type: "text",
-            text: "Refresh initiated for all series in the library",
+            text: result.message,
           }],
+          structuredContent: result,
         };
       }),
     );
@@ -676,15 +766,20 @@ export function createSonarrTools(
             "Array of episode IDs to search for",
           ),
         },
+        outputSchema: { message: z.string() },
         annotations: { idempotentHint: true, openWorldHint: false },
       },
       wrapToolHandler("sonarr_search_episodes", async (args) => {
         await sonarrClient.searchEpisodes(config, args.episodeIds);
+        const result = {
+          message: `Search initiated for ${args.episodeIds.length} episodes`,
+        };
         return {
           content: [{
             type: "text",
-            text: `Search initiated for ${args.episodeIds.length} episodes`,
+            text: result.message,
           }],
+          structuredContent: result,
         };
       }),
     );
@@ -698,15 +793,20 @@ export function createSonarrTools(
         title: "Rescan all series folders for new/missing files",
         description: "Rescan all series folders for new/missing files",
         inputSchema: {},
+        outputSchema: { message: z.string() },
         annotations: { idempotentHint: true, openWorldHint: false },
       },
       wrapToolHandler("sonarr_disk_scan", async () => {
         await sonarrClient.diskScan(config);
+        const result = {
+          message: "Disk scan initiated for all series folders",
+        };
         return {
           content: [{
             type: "text",
-            text: "Disk scan initiated for all series folders",
+            text: result.message,
           }],
+          structuredContent: result,
         };
       }),
     );

--- a/packages/media-server-mcp/src/tools/sonarr-tools.ts
+++ b/packages/media-server-mcp/src/tools/sonarr-tools.ts
@@ -2,6 +2,7 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import type { SonarrConfig, SonarrSeries } from "@wyattjoh/sonarr";
 import * as sonarrClient from "@wyattjoh/sonarr";
+import { wrapToolHandler } from "./tool-wrapper.ts";
 
 export function createSonarrTools(
   server: McpServer,
@@ -24,32 +25,22 @@ export function createSonarrTools(
             "Number of results to skip (for pagination)",
           ),
         },
+        annotations: { readOnlyHint: true, openWorldHint: false },
       },
-      async (args) => {
-        try {
-          const results = await sonarrClient.searchSeries(
-            config,
-            args.term,
-            args.limit,
-            args.skip,
-          );
-          return {
-            content: [{
-              type: "text",
-              text: JSON.stringify(results, null, 2),
-            }],
-          };
-        } catch (error) {
-          return {
-            content: [{
-              type: "text",
-              text: `Error: ${
-                error instanceof Error ? error.message : String(error)
-              }`,
-            }],
-          };
-        }
-      },
+      wrapToolHandler("sonarr_search_series", async (args) => {
+        const results = await sonarrClient.searchSeries(
+          config,
+          args.term,
+          args.limit,
+          args.skip,
+        );
+        return {
+          content: [{
+            type: "text",
+            text: JSON.stringify(results, null, 2),
+          }],
+        };
+      }),
     );
   }
 
@@ -89,43 +80,33 @@ export function createSonarrTools(
           searchForMissingEpisodes: z.boolean().optional().default(false)
             .describe("Whether to search for missing episodes after adding"),
         },
+        annotations: { openWorldHint: false },
       },
-      async (args) => {
-        try {
-          const params = {
-            ...args,
-            languageProfileId: args.languageProfileId || undefined,
-            monitored: args.monitored ?? undefined,
-            seasonFolder: args.seasonFolder ?? undefined,
-            seriesType: args.seriesType || undefined,
-            tags: args.tags || undefined,
-            seasons: args.seasons || undefined,
-            addOptions: args.searchForMissingEpisodes !== undefined
-              ? {
-                searchForMissingEpisodes: args.searchForMissingEpisodes,
-                ignoreEpisodesWithFiles: undefined,
-                ignoreEpisodesWithoutFiles: undefined,
-              }
-              : undefined,
-          };
-          const result = await sonarrClient.addSeries(config, params);
-          return {
-            content: [{
-              type: "text",
-              text: JSON.stringify(result, null, 2),
-            }],
-          };
-        } catch (error) {
-          return {
-            content: [{
-              type: "text",
-              text: `Error: ${
-                error instanceof Error ? error.message : String(error)
-              }`,
-            }],
-          };
-        }
-      },
+      wrapToolHandler("sonarr_add_series", async (args) => {
+        const params = {
+          ...args,
+          languageProfileId: args.languageProfileId || undefined,
+          monitored: args.monitored ?? undefined,
+          seasonFolder: args.seasonFolder ?? undefined,
+          seriesType: args.seriesType || undefined,
+          tags: args.tags || undefined,
+          seasons: args.seasons || undefined,
+          addOptions: args.searchForMissingEpisodes !== undefined
+            ? {
+              searchForMissingEpisodes: args.searchForMissingEpisodes,
+              ignoreEpisodesWithFiles: undefined,
+              ignoreEpisodesWithoutFiles: undefined,
+            }
+            : undefined,
+        };
+        const result = await sonarrClient.addSeries(config, params);
+        return {
+          content: [{
+            type: "text",
+            text: JSON.stringify(result, null, 2),
+          }],
+        };
+      }),
     );
   }
 
@@ -145,32 +126,22 @@ export function createSonarrTools(
             "Whether to add import exclusion",
           ),
         },
+        annotations: { destructiveHint: true, openWorldHint: false },
       },
-      async (args) => {
-        try {
-          await sonarrClient.deleteSeries(
-            config,
-            args.id,
-            args.deleteFiles,
-            args.addImportExclusion,
-          );
-          return {
-            content: [{
-              type: "text",
-              text: `Series ${args.id} deleted successfully`,
-            }],
-          };
-        } catch (error) {
-          return {
-            content: [{
-              type: "text",
-              text: `Error: ${
-                error instanceof Error ? error.message : String(error)
-              }`,
-            }],
-          };
-        }
-      },
+      wrapToolHandler("sonarr_delete_series", async (args) => {
+        await sonarrClient.deleteSeries(
+          config,
+          args.id,
+          args.deleteFiles,
+          args.addImportExclusion,
+        );
+        return {
+          content: [{
+            type: "text",
+            text: `Series ${args.id} deleted successfully`,
+          }],
+        };
+      }),
     );
   }
 
@@ -189,32 +160,22 @@ export function createSonarrTools(
             "Whether to monitor or unmonitor the episodes",
           ),
         },
+        annotations: { idempotentHint: true, openWorldHint: false },
       },
-      async (args) => {
-        try {
-          await sonarrClient.updateEpisodeMonitoring(
-            config,
-            args.episodeIds,
-            args.monitored,
-          );
-          return {
-            content: [{
-              type: "text",
-              text:
-                `Episode monitoring updated for ${args.episodeIds.length} episodes`,
-            }],
-          };
-        } catch (error) {
-          return {
-            content: [{
-              type: "text",
-              text: `Error: ${
-                error instanceof Error ? error.message : String(error)
-              }`,
-            }],
-          };
-        }
-      },
+      wrapToolHandler("sonarr_update_episode_monitoring", async (args) => {
+        await sonarrClient.updateEpisodeMonitoring(
+          config,
+          args.episodeIds,
+          args.monitored,
+        );
+        return {
+          content: [{
+            type: "text",
+            text:
+              `Episode monitoring updated for ${args.episodeIds.length} episodes`,
+          }],
+        };
+      }),
     );
   }
 
@@ -228,27 +189,17 @@ export function createSonarrTools(
         inputSchema: {
           id: z.number().describe("Series ID in Sonarr"),
         },
+        annotations: { idempotentHint: true, openWorldHint: false },
       },
-      async (args) => {
-        try {
-          await sonarrClient.refreshSeries(config, args.id);
-          return {
-            content: [{
-              type: "text",
-              text: `Series ${args.id} refresh initiated successfully`,
-            }],
-          };
-        } catch (error) {
-          return {
-            content: [{
-              type: "text",
-              text: `Error: ${
-                error instanceof Error ? error.message : String(error)
-              }`,
-            }],
-          };
-        }
-      },
+      wrapToolHandler("sonarr_refresh_series", async (args) => {
+        await sonarrClient.refreshSeries(config, args.id);
+        return {
+          content: [{
+            type: "text",
+            text: `Series ${args.id} refresh initiated successfully`,
+          }],
+        };
+      }),
     );
   }
 
@@ -262,28 +213,18 @@ export function createSonarrTools(
         inputSchema: {
           id: z.number().describe("Series ID in Sonarr"),
         },
+        annotations: { idempotentHint: true, openWorldHint: false },
       },
-      async (args) => {
-        try {
-          await sonarrClient.searchSeriesEpisodes(config, args.id);
-          return {
-            content: [{
-              type: "text",
-              text:
-                `Search for series ${args.id} episodes initiated successfully`,
-            }],
-          };
-        } catch (error) {
-          return {
-            content: [{
-              type: "text",
-              text: `Error: ${
-                error instanceof Error ? error.message : String(error)
-              }`,
-            }],
-          };
-        }
-      },
+      wrapToolHandler("sonarr_search_series_episodes", async (args) => {
+        await sonarrClient.searchSeriesEpisodes(config, args.id);
+        return {
+          content: [{
+            type: "text",
+            text:
+              `Search for series ${args.id} episodes initiated successfully`,
+          }],
+        };
+      }),
     );
   }
 
@@ -298,32 +239,22 @@ export function createSonarrTools(
           seriesId: z.number().describe("Series ID in Sonarr"),
           seasonNumber: z.number().describe("Season number to search"),
         },
+        annotations: { idempotentHint: true, openWorldHint: false },
       },
-      async (args) => {
-        try {
-          await sonarrClient.searchSeason(
-            config,
-            args.seriesId,
-            args.seasonNumber,
-          );
-          return {
-            content: [{
-              type: "text",
-              text:
-                `Search for series ${args.seriesId} season ${args.seasonNumber} initiated successfully`,
-            }],
-          };
-        } catch (error) {
-          return {
-            content: [{
-              type: "text",
-              text: `Error: ${
-                error instanceof Error ? error.message : String(error)
-              }`,
-            }],
-          };
-        }
-      },
+      wrapToolHandler("sonarr_search_season", async (args) => {
+        await sonarrClient.searchSeason(
+          config,
+          args.seriesId,
+          args.seasonNumber,
+        );
+        return {
+          content: [{
+            type: "text",
+            text:
+              `Search for series ${args.seriesId} season ${args.seasonNumber} initiated successfully`,
+          }],
+        };
+      }),
     );
   }
 
@@ -380,33 +311,23 @@ export function createSonarrTools(
             direction: z.enum(["asc", "desc"]).describe("Sort direction"),
           }).optional().describe("Sort options for series"),
         },
+        annotations: { readOnlyHint: true, openWorldHint: false },
       },
-      async (args) => {
-        try {
-          const results = await sonarrClient.getSeries(
-            config,
-            args.limit,
-            args.skip,
-            args.filters,
-            args.sort,
-          );
-          return {
-            content: [{
-              type: "text",
-              text: JSON.stringify(results, null, 2),
-            }],
-          };
-        } catch (error) {
-          return {
-            content: [{
-              type: "text",
-              text: `Error: ${
-                error instanceof Error ? error.message : String(error)
-              }`,
-            }],
-          };
-        }
-      },
+      wrapToolHandler("sonarr_get_series", async (args) => {
+        const results = await sonarrClient.getSeries(
+          config,
+          args.limit,
+          args.skip,
+          args.filters,
+          args.sort,
+        );
+        return {
+          content: [{
+            type: "text",
+            text: JSON.stringify(results, null, 2),
+          }],
+        };
+      }),
     );
   }
 
@@ -422,61 +343,51 @@ export function createSonarrTools(
           id: z.number().optional().describe("Series ID in Sonarr"),
           tvdbId: z.number().optional().describe("The TV Database (TVDB) ID"),
         },
+        annotations: { readOnlyHint: true, openWorldHint: false },
       },
-      async (args) => {
-        try {
-          // Validate that exactly one identifier is provided
-          if ((args.id === undefined) === (args.tvdbId === undefined)) {
-            return {
-              content: [{
-                type: "text",
-                text:
-                  "Error: Provide either 'id' (Sonarr ID) or 'tvdbId', but not both",
-              }],
-            };
-          }
-
-          let result;
-          if (args.id !== undefined) {
-            // Use Sonarr ID
-            result = await sonarrClient.getSeriesById(config, args.id);
-          } else if (args.tvdbId !== undefined) {
-            // Use TVDB ID
-            result = await sonarrClient.getSeriesById(config, {
-              tvdbId: args.tvdbId,
-            });
-          }
-
-          if (!result) {
-            return {
-              content: [{
-                type: "text",
-                text: `Series not found with ${
-                  args.id !== undefined
-                    ? `Sonarr ID ${args.id}`
-                    : `TVDB ID ${args.tvdbId}`
-                }`,
-              }],
-            };
-          }
-
+      wrapToolHandler("sonarr_get_series_by_id", async (args) => {
+        // Validate that exactly one identifier is provided
+        if ((args.id === undefined) === (args.tvdbId === undefined)) {
           return {
             content: [{
               type: "text",
-              text: JSON.stringify(result, null, 2),
+              text:
+                "Error: Provide either 'id' (Sonarr ID) or 'tvdbId', but not both",
             }],
           };
-        } catch (error) {
+        }
+
+        let result;
+        if (args.id !== undefined) {
+          // Use Sonarr ID
+          result = await sonarrClient.getSeriesById(config, args.id);
+        } else if (args.tvdbId !== undefined) {
+          // Use TVDB ID
+          result = await sonarrClient.getSeriesById(config, {
+            tvdbId: args.tvdbId,
+          });
+        }
+
+        if (!result) {
           return {
             content: [{
               type: "text",
-              text: `Error: ${
-                error instanceof Error ? error.message : String(error)
+              text: `Series not found with ${
+                args.id !== undefined
+                  ? `Sonarr ID ${args.id}`
+                  : `TVDB ID ${args.tvdbId}`
               }`,
             }],
           };
         }
-      },
+
+        return {
+          content: [{
+            type: "text",
+            text: JSON.stringify(result, null, 2),
+          }],
+        };
+      }),
     );
   }
 
@@ -499,33 +410,23 @@ export function createSonarrTools(
             "Number of results to skip (for pagination)",
           ),
         },
+        annotations: { readOnlyHint: true, openWorldHint: false },
       },
-      async (args) => {
-        try {
-          const results = await sonarrClient.getEpisodes(
-            config,
-            args.seriesId,
-            args.seasonNumber,
-            args.limit,
-            args.skip,
-          );
-          return {
-            content: [{
-              type: "text",
-              text: JSON.stringify(results, null, 2),
-            }],
-          };
-        } catch (error) {
-          return {
-            content: [{
-              type: "text",
-              text: `Error: ${
-                error instanceof Error ? error.message : String(error)
-              }`,
-            }],
-          };
-        }
-      },
+      wrapToolHandler("sonarr_get_episodes", async (args) => {
+        const results = await sonarrClient.getEpisodes(
+          config,
+          args.seriesId,
+          args.seasonNumber,
+          args.limit,
+          args.skip,
+        );
+        return {
+          content: [{
+            type: "text",
+            text: JSON.stringify(results, null, 2),
+          }],
+        };
+      }),
     );
   }
 
@@ -556,35 +457,25 @@ export function createSonarrTools(
             "Number of results to skip (for pagination)",
           ),
         },
+        annotations: { readOnlyHint: true, openWorldHint: false },
       },
-      async (args) => {
-        try {
-          const results = await sonarrClient.getCalendar(
-            config,
-            args.start,
-            args.end,
-            args.includeEpisodeFile,
-            args.includeSeries,
-            args.limit,
-            args.skip,
-          );
-          return {
-            content: [{
-              type: "text",
-              text: JSON.stringify(results, null, 2),
-            }],
-          };
-        } catch (error) {
-          return {
-            content: [{
-              type: "text",
-              text: `Error: ${
-                error instanceof Error ? error.message : String(error)
-              }`,
-            }],
-          };
-        }
-      },
+      wrapToolHandler("sonarr_get_calendar", async (args) => {
+        const results = await sonarrClient.getCalendar(
+          config,
+          args.start,
+          args.end,
+          args.includeEpisodeFile,
+          args.includeSeries,
+          args.limit,
+          args.skip,
+        );
+        return {
+          content: [{
+            type: "text",
+            text: JSON.stringify(results, null, 2),
+          }],
+        };
+      }),
     );
   }
 
@@ -603,31 +494,21 @@ export function createSonarrTools(
             "Number of results to skip (for pagination)",
           ),
         },
+        annotations: { readOnlyHint: true, openWorldHint: false },
       },
-      async (args) => {
-        try {
-          const results = await sonarrClient.getQueue(
-            config,
-            args.limit,
-            args.skip,
-          );
-          return {
-            content: [{
-              type: "text",
-              text: JSON.stringify(results, null, 2),
-            }],
-          };
-        } catch (error) {
-          return {
-            content: [{
-              type: "text",
-              text: `Error: ${
-                error instanceof Error ? error.message : String(error)
-              }`,
-            }],
-          };
-        }
-      },
+      wrapToolHandler("sonarr_get_queue", async (args) => {
+        const results = await sonarrClient.getQueue(
+          config,
+          args.limit,
+          args.skip,
+        );
+        return {
+          content: [{
+            type: "text",
+            text: JSON.stringify(results, null, 2),
+          }],
+        };
+      }),
     );
   }
 
@@ -641,37 +522,27 @@ export function createSonarrTools(
         description:
           "Get Sonarr configuration including quality profiles and root folders",
         inputSchema: {},
+        annotations: { readOnlyHint: true, openWorldHint: false },
       },
-      async () => {
-        try {
-          const [qualityProfiles, rootFolders] = await Promise.all([
-            sonarrClient.getQualityProfiles(config),
-            sonarrClient.getRootFolders(config),
-          ]);
-          return {
-            content: [{
-              type: "text",
-              text: JSON.stringify(
-                {
-                  qualityProfiles,
-                  rootFolders,
-                },
-                null,
-                2,
-              ),
-            }],
-          };
-        } catch (error) {
-          return {
-            content: [{
-              type: "text",
-              text: `Error: ${
-                error instanceof Error ? error.message : String(error)
-              }`,
-            }],
-          };
-        }
-      },
+      wrapToolHandler("sonarr_get_configuration", async () => {
+        const [qualityProfiles, rootFolders] = await Promise.all([
+          sonarrClient.getQualityProfiles(config),
+          sonarrClient.getRootFolders(config),
+        ]);
+        return {
+          content: [{
+            type: "text",
+            text: JSON.stringify(
+              {
+                qualityProfiles,
+                rootFolders,
+              },
+              null,
+              2,
+            ),
+          }],
+        };
+      }),
     );
   }
 
@@ -683,27 +554,17 @@ export function createSonarrTools(
         title: "Get Sonarr system status",
         description: "Get Sonarr system status",
         inputSchema: {},
+        annotations: { readOnlyHint: true, openWorldHint: false },
       },
-      async () => {
-        try {
-          const result = await sonarrClient.getSystemStatus(config);
-          return {
-            content: [{
-              type: "text",
-              text: JSON.stringify(result, null, 2),
-            }],
-          };
-        } catch (error) {
-          return {
-            content: [{
-              type: "text",
-              text: `Error: ${
-                error instanceof Error ? error.message : String(error)
-              }`,
-            }],
-          };
-        }
-      },
+      wrapToolHandler("sonarr_get_system_status", async () => {
+        const result = await sonarrClient.getSystemStatus(config);
+        return {
+          content: [{
+            type: "text",
+            text: JSON.stringify(result, null, 2),
+          }],
+        };
+      }),
     );
   }
 
@@ -715,27 +576,17 @@ export function createSonarrTools(
         title: "Get Sonarr health check results",
         description: "Get Sonarr health check results",
         inputSchema: {},
+        annotations: { readOnlyHint: true, openWorldHint: false },
       },
-      async () => {
-        try {
-          const results = await sonarrClient.getHealth(config);
-          return {
-            content: [{
-              type: "text",
-              text: JSON.stringify(results, null, 2),
-            }],
-          };
-        } catch (error) {
-          return {
-            content: [{
-              type: "text",
-              text: `Error: ${
-                error instanceof Error ? error.message : String(error)
-              }`,
-            }],
-          };
-        }
-      },
+      wrapToolHandler("sonarr_get_health", async () => {
+        const results = await sonarrClient.getHealth(config);
+        return {
+          content: [{
+            type: "text",
+            text: JSON.stringify(results, null, 2),
+          }],
+        };
+      }),
     );
   }
 
@@ -752,28 +603,18 @@ export function createSonarrTools(
             "Series object with updated fields",
           ),
         },
+        annotations: { idempotentHint: true, openWorldHint: false },
       },
-      async (args) => {
-        try {
-          const series = { ...args.series, id: args.id } as SonarrSeries;
-          const result = await sonarrClient.updateSeries(config, series);
-          return {
-            content: [{
-              type: "text",
-              text: JSON.stringify(result, null, 2),
-            }],
-          };
-        } catch (error) {
-          return {
-            content: [{
-              type: "text",
-              text: `Error: ${
-                error instanceof Error ? error.message : String(error)
-              }`,
-            }],
-          };
-        }
-      },
+      wrapToolHandler("sonarr_update_series", async (args) => {
+        const series = { ...args.series, id: args.id } as SonarrSeries;
+        const result = await sonarrClient.updateSeries(config, series);
+        return {
+          content: [{
+            type: "text",
+            text: JSON.stringify(result, null, 2),
+          }],
+        };
+      }),
     );
   }
 
@@ -787,27 +628,17 @@ export function createSonarrTools(
         inputSchema: {
           id: z.number().describe("Episode ID in Sonarr"),
         },
+        annotations: { readOnlyHint: true, openWorldHint: false },
       },
-      async (args) => {
-        try {
-          const result = await sonarrClient.getEpisodeById(config, args.id);
-          return {
-            content: [{
-              type: "text",
-              text: JSON.stringify(result, null, 2),
-            }],
-          };
-        } catch (error) {
-          return {
-            content: [{
-              type: "text",
-              text: `Error: ${
-                error instanceof Error ? error.message : String(error)
-              }`,
-            }],
-          };
-        }
-      },
+      wrapToolHandler("sonarr_get_episode", async (args) => {
+        const result = await sonarrClient.getEpisodeById(config, args.id);
+        return {
+          content: [{
+            type: "text",
+            text: JSON.stringify(result, null, 2),
+          }],
+        };
+      }),
     );
   }
 
@@ -819,27 +650,17 @@ export function createSonarrTools(
         title: "Refresh metadata for all series in the library",
         description: "Refresh metadata for all series in the library",
         inputSchema: {},
+        annotations: { idempotentHint: true, openWorldHint: false },
       },
-      async () => {
-        try {
-          await sonarrClient.refreshAllSeries(config);
-          return {
-            content: [{
-              type: "text",
-              text: "Refresh initiated for all series in the library",
-            }],
-          };
-        } catch (error) {
-          return {
-            content: [{
-              type: "text",
-              text: `Error: ${
-                error instanceof Error ? error.message : String(error)
-              }`,
-            }],
-          };
-        }
-      },
+      wrapToolHandler("sonarr_refresh_all_series", async () => {
+        await sonarrClient.refreshAllSeries(config);
+        return {
+          content: [{
+            type: "text",
+            text: "Refresh initiated for all series in the library",
+          }],
+        };
+      }),
     );
   }
 
@@ -855,27 +676,17 @@ export function createSonarrTools(
             "Array of episode IDs to search for",
           ),
         },
+        annotations: { idempotentHint: true, openWorldHint: false },
       },
-      async (args) => {
-        try {
-          await sonarrClient.searchEpisodes(config, args.episodeIds);
-          return {
-            content: [{
-              type: "text",
-              text: `Search initiated for ${args.episodeIds.length} episodes`,
-            }],
-          };
-        } catch (error) {
-          return {
-            content: [{
-              type: "text",
-              text: `Error: ${
-                error instanceof Error ? error.message : String(error)
-              }`,
-            }],
-          };
-        }
-      },
+      wrapToolHandler("sonarr_search_episodes", async (args) => {
+        await sonarrClient.searchEpisodes(config, args.episodeIds);
+        return {
+          content: [{
+            type: "text",
+            text: `Search initiated for ${args.episodeIds.length} episodes`,
+          }],
+        };
+      }),
     );
   }
 
@@ -887,27 +698,17 @@ export function createSonarrTools(
         title: "Rescan all series folders for new/missing files",
         description: "Rescan all series folders for new/missing files",
         inputSchema: {},
+        annotations: { idempotentHint: true, openWorldHint: false },
       },
-      async () => {
-        try {
-          await sonarrClient.diskScan(config);
-          return {
-            content: [{
-              type: "text",
-              text: "Disk scan initiated for all series folders",
-            }],
-          };
-        } catch (error) {
-          return {
-            content: [{
-              type: "text",
-              text: `Error: ${
-                error instanceof Error ? error.message : String(error)
-              }`,
-            }],
-          };
-        }
-      },
+      wrapToolHandler("sonarr_disk_scan", async () => {
+        await sonarrClient.diskScan(config);
+        return {
+          content: [{
+            type: "text",
+            text: "Disk scan initiated for all series folders",
+          }],
+        };
+      }),
     );
   }
 }

--- a/packages/media-server-mcp/src/tools/tmdb-tools.ts
+++ b/packages/media-server-mcp/src/tools/tmdb-tools.ts
@@ -4,6 +4,15 @@ import type { TMDBConfig } from "@wyattjoh/tmdb";
 import * as tmdbClient from "@wyattjoh/tmdb";
 import { wrapToolHandler } from "./tool-wrapper.ts";
 
+// Reusable output schema shape for paginated TMDB responses.
+// toPaginatedResponse() always returns { page, total_pages, total_results, results }.
+const paginatedOutputSchema = {
+  page: z.number(),
+  total_pages: z.number(),
+  total_results: z.number(),
+  results: z.array(z.record(z.string(), z.unknown())),
+};
+
 export function createTMDBTools(
   server: McpServer,
   config: TMDBConfig,
@@ -26,6 +35,7 @@ export function createTMDBTools(
             "External source (default: 'imdb_id')",
           ),
         },
+        outputSchema: z.record(z.string(), z.unknown()),
         annotations: { readOnlyHint: true, openWorldHint: false },
       },
       wrapToolHandler("tmdb_find_by_external_id", async (args) => {
@@ -39,6 +49,7 @@ export function createTMDBTools(
             type: "text",
             text: JSON.stringify(result, null, 2),
           }],
+          structuredContent: result as unknown as Record<string, unknown>,
         };
       }),
     );
@@ -60,6 +71,7 @@ export function createTMDBTools(
             "Language code (e.g., 'en-US')",
           ),
         },
+        outputSchema: paginatedOutputSchema,
         annotations: { readOnlyHint: true, openWorldHint: false },
       },
       wrapToolHandler("tmdb_search_movies", async (args) => {
@@ -75,6 +87,7 @@ export function createTMDBTools(
             type: "text",
             text: JSON.stringify(result, null, 2),
           }],
+          structuredContent: result as unknown as Record<string, unknown>,
         };
       }),
     );
@@ -96,6 +109,7 @@ export function createTMDBTools(
             "Language code (e.g., 'en-US')",
           ),
         },
+        outputSchema: paginatedOutputSchema,
         annotations: { readOnlyHint: true, openWorldHint: false },
       },
       wrapToolHandler("tmdb_search_tv", async (args) => {
@@ -111,6 +125,7 @@ export function createTMDBTools(
             type: "text",
             text: JSON.stringify(result, null, 2),
           }],
+          structuredContent: result as unknown as Record<string, unknown>,
         };
       }),
     );
@@ -136,6 +151,7 @@ export function createTMDBTools(
             "Language code (e.g., 'en-US')",
           ),
         },
+        outputSchema: paginatedOutputSchema,
         annotations: { readOnlyHint: true, openWorldHint: false },
       },
       wrapToolHandler("tmdb_search_multi", async (args) => {
@@ -151,6 +167,7 @@ export function createTMDBTools(
             type: "text",
             text: JSON.stringify(result, null, 2),
           }],
+          structuredContent: result as unknown as Record<string, unknown>,
         };
       }),
     );
@@ -171,6 +188,7 @@ export function createTMDBTools(
             "Language code (e.g., 'en-US')",
           ),
         },
+        outputSchema: paginatedOutputSchema,
         annotations: { readOnlyHint: true, openWorldHint: false },
       },
       wrapToolHandler("tmdb_get_popular_movies", async (args) => {
@@ -185,6 +203,7 @@ export function createTMDBTools(
             type: "text",
             text: JSON.stringify(result, null, 2),
           }],
+          structuredContent: result as unknown as Record<string, unknown>,
         };
       }),
     );
@@ -254,6 +273,7 @@ export function createTMDBTools(
           ),
           year: z.number().optional().describe("Filter by release year"),
         },
+        outputSchema: paginatedOutputSchema,
         annotations: { readOnlyHint: true, openWorldHint: false },
       },
       wrapToolHandler("tmdb_discover_movies", async (args) => {
@@ -275,6 +295,7 @@ export function createTMDBTools(
             type: "text",
             text: JSON.stringify(result, null, 2),
           }],
+          structuredContent: result as unknown as Record<string, unknown>,
         };
       }),
     );
@@ -338,6 +359,7 @@ export function createTMDBTools(
             "Filter by theatrical screening",
           ),
         },
+        outputSchema: paginatedOutputSchema,
         annotations: { readOnlyHint: true, openWorldHint: false },
       },
       wrapToolHandler("tmdb_discover_tv", async (args) => {
@@ -356,6 +378,7 @@ export function createTMDBTools(
             type: "text",
             text: JSON.stringify(result, null, 2),
           }],
+          structuredContent: result as unknown as Record<string, unknown>,
         };
       }),
     );
@@ -374,6 +397,9 @@ export function createTMDBTools(
             "Language code (e.g., 'en-US')",
           ),
         },
+        outputSchema: {
+          genres: z.array(z.record(z.string(), z.unknown())),
+        },
         annotations: { readOnlyHint: true, openWorldHint: false },
       },
       wrapToolHandler("tmdb_get_genres", async (args) => {
@@ -386,6 +412,7 @@ export function createTMDBTools(
             type: "text",
             text: JSON.stringify(result, null, 2),
           }],
+          structuredContent: result as unknown as Record<string, unknown>,
         };
       }),
     );
@@ -414,6 +441,7 @@ export function createTMDBTools(
             "Language code (e.g., 'en-US')",
           ),
         },
+        outputSchema: paginatedOutputSchema,
         annotations: { readOnlyHint: true, openWorldHint: false },
       },
       wrapToolHandler("tmdb_get_trending", async (args) => {
@@ -430,6 +458,7 @@ export function createTMDBTools(
             type: "text",
             text: JSON.stringify(result, null, 2),
           }],
+          structuredContent: result as unknown as Record<string, unknown>,
         };
       }),
     );
@@ -453,6 +482,7 @@ export function createTMDBTools(
             "Region for release dates (ISO 3166-1)",
           ),
         },
+        outputSchema: paginatedOutputSchema,
         annotations: { readOnlyHint: true, openWorldHint: false },
       },
       wrapToolHandler("tmdb_get_now_playing_movies", async (args) => {
@@ -468,6 +498,7 @@ export function createTMDBTools(
             type: "text",
             text: JSON.stringify(result, null, 2),
           }],
+          structuredContent: result as unknown as Record<string, unknown>,
         };
       }),
     );
@@ -491,6 +522,7 @@ export function createTMDBTools(
             "Region for release dates (ISO 3166-1)",
           ),
         },
+        outputSchema: paginatedOutputSchema,
         annotations: { readOnlyHint: true, openWorldHint: false },
       },
       wrapToolHandler("tmdb_get_top_rated_movies", async (args) => {
@@ -506,6 +538,7 @@ export function createTMDBTools(
             type: "text",
             text: JSON.stringify(result, null, 2),
           }],
+          structuredContent: result as unknown as Record<string, unknown>,
         };
       }),
     );
@@ -529,6 +562,7 @@ export function createTMDBTools(
             "Region for release dates (ISO 3166-1)",
           ),
         },
+        outputSchema: paginatedOutputSchema,
         annotations: { readOnlyHint: true, openWorldHint: false },
       },
       wrapToolHandler("tmdb_get_upcoming_movies", async (args) => {
@@ -544,6 +578,7 @@ export function createTMDBTools(
             type: "text",
             text: JSON.stringify(result, null, 2),
           }],
+          structuredContent: result as unknown as Record<string, unknown>,
         };
       }),
     );
@@ -564,6 +599,7 @@ export function createTMDBTools(
             "Language code (e.g., 'en-US')",
           ),
         },
+        outputSchema: paginatedOutputSchema,
         annotations: { readOnlyHint: true, openWorldHint: false },
       },
       wrapToolHandler("tmdb_get_popular_tv", async (args) => {
@@ -578,6 +614,7 @@ export function createTMDBTools(
             type: "text",
             text: JSON.stringify(result, null, 2),
           }],
+          structuredContent: result as unknown as Record<string, unknown>,
         };
       }),
     );
@@ -598,6 +635,7 @@ export function createTMDBTools(
             "Language code (e.g., 'en-US')",
           ),
         },
+        outputSchema: paginatedOutputSchema,
         annotations: { readOnlyHint: true, openWorldHint: false },
       },
       wrapToolHandler("tmdb_get_top_rated_tv", async (args) => {
@@ -612,6 +650,7 @@ export function createTMDBTools(
             type: "text",
             text: JSON.stringify(result, null, 2),
           }],
+          structuredContent: result as unknown as Record<string, unknown>,
         };
       }),
     );
@@ -632,6 +671,7 @@ export function createTMDBTools(
             "Language code (e.g., 'en-US')",
           ),
         },
+        outputSchema: paginatedOutputSchema,
         annotations: { readOnlyHint: true, openWorldHint: false },
       },
       wrapToolHandler("tmdb_get_on_the_air_tv", async (args) => {
@@ -646,6 +686,7 @@ export function createTMDBTools(
             type: "text",
             text: JSON.stringify(result, null, 2),
           }],
+          structuredContent: result as unknown as Record<string, unknown>,
         };
       }),
     );
@@ -667,6 +708,7 @@ export function createTMDBTools(
           ),
           timezone: z.string().optional().describe("Timezone for air dates"),
         },
+        outputSchema: paginatedOutputSchema,
         annotations: { readOnlyHint: true, openWorldHint: false },
       },
       wrapToolHandler("tmdb_get_airing_today_tv", async (args) => {
@@ -682,6 +724,7 @@ export function createTMDBTools(
             type: "text",
             text: JSON.stringify(result, null, 2),
           }],
+          structuredContent: result as unknown as Record<string, unknown>,
         };
       }),
     );
@@ -703,6 +746,7 @@ export function createTMDBTools(
             "Comma-separated list of additional details to append (e.g., 'credits,videos')",
           ),
         },
+        outputSchema: z.record(z.string(), z.unknown()),
         annotations: { readOnlyHint: true, openWorldHint: false },
       },
       wrapToolHandler("tmdb_get_movie_details", async (args) => {
@@ -713,6 +757,7 @@ export function createTMDBTools(
             type: "text",
             text: JSON.stringify(result, null, 2),
           }],
+          structuredContent: result as unknown as Record<string, unknown>,
         };
       }),
     );
@@ -734,6 +779,7 @@ export function createTMDBTools(
             "Comma-separated list of additional details to append (e.g., 'credits,videos')",
           ),
         },
+        outputSchema: z.record(z.string(), z.unknown()),
         annotations: { readOnlyHint: true, openWorldHint: false },
       },
       wrapToolHandler("tmdb_get_tv_details", async (args) => {
@@ -744,6 +790,7 @@ export function createTMDBTools(
             type: "text",
             text: JSON.stringify(result, null, 2),
           }],
+          structuredContent: result as unknown as Record<string, unknown>,
         };
       }),
     );
@@ -765,6 +812,7 @@ export function createTMDBTools(
             "Language code (e.g., 'en-US')",
           ),
         },
+        outputSchema: paginatedOutputSchema,
         annotations: { readOnlyHint: true, openWorldHint: false },
       },
       wrapToolHandler("tmdb_get_movie_recommendations", async (args) => {
@@ -780,6 +828,7 @@ export function createTMDBTools(
             type: "text",
             text: JSON.stringify(result, null, 2),
           }],
+          structuredContent: result as unknown as Record<string, unknown>,
         };
       }),
     );
@@ -801,6 +850,7 @@ export function createTMDBTools(
             "Language code (e.g., 'en-US')",
           ),
         },
+        outputSchema: paginatedOutputSchema,
         annotations: { readOnlyHint: true, openWorldHint: false },
       },
       wrapToolHandler("tmdb_get_tv_recommendations", async (args) => {
@@ -816,6 +866,7 @@ export function createTMDBTools(
             type: "text",
             text: JSON.stringify(result, null, 2),
           }],
+          structuredContent: result as unknown as Record<string, unknown>,
         };
       }),
     );
@@ -837,6 +888,7 @@ export function createTMDBTools(
             "Language code (e.g., 'en-US')",
           ),
         },
+        outputSchema: paginatedOutputSchema,
         annotations: { readOnlyHint: true, openWorldHint: false },
       },
       wrapToolHandler("tmdb_get_similar_movies", async (args) => {
@@ -852,6 +904,7 @@ export function createTMDBTools(
             type: "text",
             text: JSON.stringify(result, null, 2),
           }],
+          structuredContent: result as unknown as Record<string, unknown>,
         };
       }),
     );
@@ -873,6 +926,7 @@ export function createTMDBTools(
             "Language code (e.g., 'en-US')",
           ),
         },
+        outputSchema: paginatedOutputSchema,
         annotations: { readOnlyHint: true, openWorldHint: false },
       },
       wrapToolHandler("tmdb_get_similar_tv", async (args) => {
@@ -888,6 +942,7 @@ export function createTMDBTools(
             type: "text",
             text: JSON.stringify(result, null, 2),
           }],
+          structuredContent: result as unknown as Record<string, unknown>,
         };
       }),
     );
@@ -912,6 +967,7 @@ export function createTMDBTools(
             "Include adult content",
           ),
         },
+        outputSchema: paginatedOutputSchema,
         annotations: { readOnlyHint: true, openWorldHint: false },
       },
       wrapToolHandler("tmdb_search_people", async (args) => {
@@ -928,6 +984,7 @@ export function createTMDBTools(
             type: "text",
             text: JSON.stringify(result, null, 2),
           }],
+          structuredContent: result as unknown as Record<string, unknown>,
         };
       }),
     );
@@ -948,6 +1005,7 @@ export function createTMDBTools(
             "Language code (e.g., 'en-US')",
           ),
         },
+        outputSchema: paginatedOutputSchema,
         annotations: { readOnlyHint: true, openWorldHint: false },
       },
       wrapToolHandler("tmdb_get_popular_people", async (args) => {
@@ -962,6 +1020,7 @@ export function createTMDBTools(
             type: "text",
             text: JSON.stringify(result, null, 2),
           }],
+          structuredContent: result as unknown as Record<string, unknown>,
         };
       }),
     );
@@ -983,6 +1042,7 @@ export function createTMDBTools(
             "Comma-separated list of additional details to append (e.g., 'movie_credits,tv_credits')",
           ),
         },
+        outputSchema: z.record(z.string(), z.unknown()),
         annotations: { readOnlyHint: true, openWorldHint: false },
       },
       wrapToolHandler("tmdb_get_person_details", async (args) => {
@@ -998,6 +1058,7 @@ export function createTMDBTools(
             type: "text",
             text: JSON.stringify(result, null, 2),
           }],
+          structuredContent: result as unknown as Record<string, unknown>,
         };
       }),
     );
@@ -1016,6 +1077,10 @@ export function createTMDBTools(
             "Language code (e.g., 'en-US')",
           ),
         },
+        outputSchema: {
+          cast: z.array(z.record(z.string(), z.unknown())),
+          crew: z.array(z.record(z.string(), z.unknown())),
+        },
         annotations: { readOnlyHint: true, openWorldHint: false },
       },
       wrapToolHandler("tmdb_get_person_movie_credits", async (args) => {
@@ -1030,6 +1095,7 @@ export function createTMDBTools(
             type: "text",
             text: JSON.stringify(result, null, 2),
           }],
+          structuredContent: result as unknown as Record<string, unknown>,
         };
       }),
     );
@@ -1048,6 +1114,10 @@ export function createTMDBTools(
             "Language code (e.g., 'en-US')",
           ),
         },
+        outputSchema: {
+          cast: z.array(z.record(z.string(), z.unknown())),
+          crew: z.array(z.record(z.string(), z.unknown())),
+        },
         annotations: { readOnlyHint: true, openWorldHint: false },
       },
       wrapToolHandler("tmdb_get_person_tv_credits", async (args) => {
@@ -1062,6 +1132,7 @@ export function createTMDBTools(
             type: "text",
             text: JSON.stringify(result, null, 2),
           }],
+          structuredContent: result as unknown as Record<string, unknown>,
         };
       }),
     );
@@ -1083,6 +1154,7 @@ export function createTMDBTools(
             "Language code (e.g., 'en-US')",
           ),
         },
+        outputSchema: paginatedOutputSchema,
         annotations: { readOnlyHint: true, openWorldHint: false },
       },
       wrapToolHandler("tmdb_search_collections", async (args) => {
@@ -1098,6 +1170,7 @@ export function createTMDBTools(
             type: "text",
             text: JSON.stringify(result, null, 2),
           }],
+          structuredContent: result as unknown as Record<string, unknown>,
         };
       }),
     );
@@ -1116,6 +1189,7 @@ export function createTMDBTools(
             "Language code (e.g., 'en-US')",
           ),
         },
+        outputSchema: z.record(z.string(), z.unknown()),
         annotations: { readOnlyHint: true, openWorldHint: false },
       },
       wrapToolHandler("tmdb_get_collection_details", async (args) => {
@@ -1130,6 +1204,7 @@ export function createTMDBTools(
             type: "text",
             text: JSON.stringify(result, null, 2),
           }],
+          structuredContent: result as unknown as Record<string, unknown>,
         };
       }),
     );
@@ -1148,6 +1223,7 @@ export function createTMDBTools(
             "Page number (1-1000)",
           ),
         },
+        outputSchema: paginatedOutputSchema,
         annotations: { readOnlyHint: true, openWorldHint: false },
       },
       wrapToolHandler("tmdb_search_keywords", async (args) => {
@@ -1162,6 +1238,7 @@ export function createTMDBTools(
             type: "text",
             text: JSON.stringify(result, null, 2),
           }],
+          structuredContent: result as unknown as Record<string, unknown>,
         };
       }),
     );
@@ -1186,6 +1263,7 @@ export function createTMDBTools(
             "Include adult movies",
           ),
         },
+        outputSchema: paginatedOutputSchema,
         annotations: { readOnlyHint: true, openWorldHint: false },
       },
       wrapToolHandler("tmdb_get_movies_by_keyword", async (args) => {
@@ -1202,6 +1280,7 @@ export function createTMDBTools(
             type: "text",
             text: JSON.stringify(result, null, 2),
           }],
+          structuredContent: result as unknown as Record<string, unknown>,
         };
       }),
     );
@@ -1219,6 +1298,7 @@ export function createTMDBTools(
             "Media type for certifications",
           ),
         },
+        outputSchema: z.record(z.string(), z.unknown()),
         annotations: { readOnlyHint: true, openWorldHint: false },
       },
       wrapToolHandler("tmdb_get_certifications", async (args) => {
@@ -1232,6 +1312,7 @@ export function createTMDBTools(
             type: "text",
             text: JSON.stringify(result, null, 2),
           }],
+          structuredContent: result as unknown as Record<string, unknown>,
         };
       }),
     );
@@ -1248,6 +1329,7 @@ export function createTMDBTools(
           mediaType: z.enum(["movie", "tv"]).describe("Media type"),
           mediaId: z.number().describe("The TMDB ID of the movie or TV show"),
         },
+        outputSchema: z.record(z.string(), z.unknown()),
         annotations: { readOnlyHint: true, openWorldHint: false },
       },
       wrapToolHandler("tmdb_get_watch_providers", async (args) => {
@@ -1262,6 +1344,7 @@ export function createTMDBTools(
             type: "text",
             text: JSON.stringify(result, null, 2),
           }],
+          structuredContent: result as unknown as Record<string, unknown>,
         };
       }),
     );
@@ -1275,6 +1358,7 @@ export function createTMDBTools(
         title: "Get TMDB API configuration including image base URLs",
         description: "Get TMDB API configuration including image base URLs",
         inputSchema: {},
+        outputSchema: z.record(z.string(), z.unknown()),
         annotations: { readOnlyHint: true, openWorldHint: false },
       },
       wrapToolHandler("tmdb_get_configuration", async () => {
@@ -1285,6 +1369,7 @@ export function createTMDBTools(
             type: "text",
             text: JSON.stringify(result, null, 2),
           }],
+          structuredContent: result as unknown as Record<string, unknown>,
         };
       }),
     );
@@ -1302,6 +1387,9 @@ export function createTMDBTools(
             "Language code (e.g., 'en-US')",
           ),
         },
+        outputSchema: {
+          countries: z.array(z.record(z.string(), z.unknown())),
+        },
         annotations: { readOnlyHint: true, openWorldHint: false },
       },
       wrapToolHandler("tmdb_get_countries", async (args) => {
@@ -1312,6 +1400,10 @@ export function createTMDBTools(
             type: "text",
             text: JSON.stringify(result, null, 2),
           }],
+          structuredContent: { countries: result } as unknown as Record<
+            string,
+            unknown
+          >,
         };
       }),
     );
@@ -1325,6 +1417,9 @@ export function createTMDBTools(
         title: "Get list of languages used in TMDB",
         description: "Get list of languages used in TMDB",
         inputSchema: {},
+        outputSchema: {
+          languages: z.array(z.record(z.string(), z.unknown())),
+        },
         annotations: { readOnlyHint: true, openWorldHint: false },
       },
       wrapToolHandler("tmdb_get_languages", async () => {
@@ -1335,6 +1430,10 @@ export function createTMDBTools(
             type: "text",
             text: JSON.stringify(result, null, 2),
           }],
+          structuredContent: { languages: result } as unknown as Record<
+            string,
+            unknown
+          >,
         };
       }),
     );
@@ -1350,6 +1449,10 @@ export function createTMDBTools(
         inputSchema: {
           movieId: z.number().describe("The TMDB movie ID"),
         },
+        outputSchema: {
+          cast: z.array(z.record(z.string(), z.unknown())),
+          crew: z.array(z.record(z.string(), z.unknown())),
+        },
         annotations: { readOnlyHint: true, openWorldHint: false },
       },
       wrapToolHandler("tmdb_get_movie_credits", async (args) => {
@@ -1360,6 +1463,7 @@ export function createTMDBTools(
             type: "text",
             text: JSON.stringify(result, null, 2),
           }],
+          structuredContent: result as unknown as Record<string, unknown>,
         };
       }),
     );
@@ -1375,6 +1479,10 @@ export function createTMDBTools(
         inputSchema: {
           tvId: z.number().describe("The TMDB TV show ID"),
         },
+        outputSchema: {
+          cast: z.array(z.record(z.string(), z.unknown())),
+          crew: z.array(z.record(z.string(), z.unknown())),
+        },
         annotations: { readOnlyHint: true, openWorldHint: false },
       },
       wrapToolHandler("tmdb_get_tv_credits", async (args) => {
@@ -1385,6 +1493,7 @@ export function createTMDBTools(
             type: "text",
             text: JSON.stringify(result, null, 2),
           }],
+          structuredContent: result as unknown as Record<string, unknown>,
         };
       }),
     );

--- a/packages/media-server-mcp/src/tools/tmdb-tools.ts
+++ b/packages/media-server-mcp/src/tools/tmdb-tools.ts
@@ -2,6 +2,7 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import type { TMDBConfig } from "@wyattjoh/tmdb";
 import * as tmdbClient from "@wyattjoh/tmdb";
+import { wrapToolHandler } from "./tool-wrapper.ts";
 
 export function createTMDBTools(
   server: McpServer,
@@ -25,31 +26,21 @@ export function createTMDBTools(
             "External source (default: 'imdb_id')",
           ),
         },
+        annotations: { readOnlyHint: true, openWorldHint: false },
       },
-      async (args) => {
-        try {
-          const result = await tmdbClient.findByExternalId(
-            config,
-            args.externalId,
-            args.externalSource,
-          );
-          return {
-            content: [{
-              type: "text",
-              text: JSON.stringify(result, null, 2),
-            }],
-          };
-        } catch (error) {
-          return {
-            content: [{
-              type: "text",
-              text: `Error: ${
-                error instanceof Error ? error.message : String(error)
-              }`,
-            }],
-          };
-        }
-      },
+      wrapToolHandler("tmdb_find_by_external_id", async (args) => {
+        const result = await tmdbClient.findByExternalId(
+          config,
+          args.externalId,
+          args.externalSource,
+        );
+        return {
+          content: [{
+            type: "text",
+            text: JSON.stringify(result, null, 2),
+          }],
+        };
+      }),
     );
   }
 
@@ -69,33 +60,23 @@ export function createTMDBTools(
             "Language code (e.g., 'en-US')",
           ),
         },
+        annotations: { readOnlyHint: true, openWorldHint: false },
       },
-      async (args) => {
-        try {
-          const result = await tmdbClient.searchMovies(
-            config,
-            args.query,
-            args.page,
-            args.language,
-          );
+      wrapToolHandler("tmdb_search_movies", async (args) => {
+        const result = await tmdbClient.searchMovies(
+          config,
+          args.query,
+          args.page,
+          args.language,
+        );
 
-          return {
-            content: [{
-              type: "text",
-              text: JSON.stringify(result, null, 2),
-            }],
-          };
-        } catch (error) {
-          return {
-            content: [{
-              type: "text",
-              text: `Error: ${
-                error instanceof Error ? error.message : String(error)
-              }`,
-            }],
-          };
-        }
-      },
+        return {
+          content: [{
+            type: "text",
+            text: JSON.stringify(result, null, 2),
+          }],
+        };
+      }),
     );
   }
 
@@ -115,33 +96,23 @@ export function createTMDBTools(
             "Language code (e.g., 'en-US')",
           ),
         },
+        annotations: { readOnlyHint: true, openWorldHint: false },
       },
-      async (args) => {
-        try {
-          const result = await tmdbClient.searchTV(
-            config,
-            args.query,
-            args.page,
-            args.language,
-          );
+      wrapToolHandler("tmdb_search_tv", async (args) => {
+        const result = await tmdbClient.searchTV(
+          config,
+          args.query,
+          args.page,
+          args.language,
+        );
 
-          return {
-            content: [{
-              type: "text",
-              text: JSON.stringify(result, null, 2),
-            }],
-          };
-        } catch (error) {
-          return {
-            content: [{
-              type: "text",
-              text: `Error: ${
-                error instanceof Error ? error.message : String(error)
-              }`,
-            }],
-          };
-        }
-      },
+        return {
+          content: [{
+            type: "text",
+            text: JSON.stringify(result, null, 2),
+          }],
+        };
+      }),
     );
   }
 
@@ -165,33 +136,23 @@ export function createTMDBTools(
             "Language code (e.g., 'en-US')",
           ),
         },
+        annotations: { readOnlyHint: true, openWorldHint: false },
       },
-      async (args) => {
-        try {
-          const result = await tmdbClient.searchMulti(
-            config,
-            args.query,
-            args.page,
-            args.language,
-          );
+      wrapToolHandler("tmdb_search_multi", async (args) => {
+        const result = await tmdbClient.searchMulti(
+          config,
+          args.query,
+          args.page,
+          args.language,
+        );
 
-          return {
-            content: [{
-              type: "text",
-              text: JSON.stringify(result, null, 2),
-            }],
-          };
-        } catch (error) {
-          return {
-            content: [{
-              type: "text",
-              text: `Error: ${
-                error instanceof Error ? error.message : String(error)
-              }`,
-            }],
-          };
-        }
-      },
+        return {
+          content: [{
+            type: "text",
+            text: JSON.stringify(result, null, 2),
+          }],
+        };
+      }),
     );
   }
 
@@ -210,32 +171,22 @@ export function createTMDBTools(
             "Language code (e.g., 'en-US')",
           ),
         },
+        annotations: { readOnlyHint: true, openWorldHint: false },
       },
-      async (args) => {
-        try {
-          const result = await tmdbClient.getPopularMovies(
-            config,
-            args.page,
-            args.language,
-          );
+      wrapToolHandler("tmdb_get_popular_movies", async (args) => {
+        const result = await tmdbClient.getPopularMovies(
+          config,
+          args.page,
+          args.language,
+        );
 
-          return {
-            content: [{
-              type: "text",
-              text: JSON.stringify(result, null, 2),
-            }],
-          };
-        } catch (error) {
-          return {
-            content: [{
-              type: "text",
-              text: `Error: ${
-                error instanceof Error ? error.message : String(error)
-              }`,
-            }],
-          };
-        }
-      },
+        return {
+          content: [{
+            type: "text",
+            text: JSON.stringify(result, null, 2),
+          }],
+        };
+      }),
     );
   }
 
@@ -303,39 +254,29 @@ export function createTMDBTools(
           ),
           year: z.number().optional().describe("Filter by release year"),
         },
+        annotations: { readOnlyHint: true, openWorldHint: false },
       },
-      async (args) => {
-        try {
-          // Filter out undefined values
-          const cleanedOptions: Record<string, string | number | boolean> = {};
-          Object.entries(args).forEach(([key, value]) => {
-            if (value !== undefined) {
-              cleanedOptions[key] = value;
-            }
-          });
+      wrapToolHandler("tmdb_discover_movies", async (args) => {
+        // Filter out undefined values
+        const cleanedOptions: Record<string, string | number | boolean> = {};
+        Object.entries(args).forEach(([key, value]) => {
+          if (value !== undefined) {
+            cleanedOptions[key] = value;
+          }
+        });
 
-          const result = await tmdbClient.discoverMovies(
-            config,
-            cleanedOptions,
-          );
+        const result = await tmdbClient.discoverMovies(
+          config,
+          cleanedOptions,
+        );
 
-          return {
-            content: [{
-              type: "text",
-              text: JSON.stringify(result, null, 2),
-            }],
-          };
-        } catch (error) {
-          return {
-            content: [{
-              type: "text",
-              text: `Error: ${
-                error instanceof Error ? error.message : String(error)
-              }`,
-            }],
-          };
-        }
-      },
+        return {
+          content: [{
+            type: "text",
+            text: JSON.stringify(result, null, 2),
+          }],
+        };
+      }),
     );
   }
 
@@ -397,36 +338,26 @@ export function createTMDBTools(
             "Filter by theatrical screening",
           ),
         },
+        annotations: { readOnlyHint: true, openWorldHint: false },
       },
-      async (args) => {
-        try {
-          // Filter out undefined values
-          const cleanedOptions: Record<string, string | number | boolean> = {};
-          Object.entries(args).forEach(([key, value]) => {
-            if (value !== undefined) {
-              cleanedOptions[key] = value;
-            }
-          });
+      wrapToolHandler("tmdb_discover_tv", async (args) => {
+        // Filter out undefined values
+        const cleanedOptions: Record<string, string | number | boolean> = {};
+        Object.entries(args).forEach(([key, value]) => {
+          if (value !== undefined) {
+            cleanedOptions[key] = value;
+          }
+        });
 
-          const result = await tmdbClient.discoverTV(config, cleanedOptions);
+        const result = await tmdbClient.discoverTV(config, cleanedOptions);
 
-          return {
-            content: [{
-              type: "text",
-              text: JSON.stringify(result, null, 2),
-            }],
-          };
-        } catch (error) {
-          return {
-            content: [{
-              type: "text",
-              text: `Error: ${
-                error instanceof Error ? error.message : String(error)
-              }`,
-            }],
-          };
-        }
-      },
+        return {
+          content: [{
+            type: "text",
+            text: JSON.stringify(result, null, 2),
+          }],
+        };
+      }),
     );
   }
 
@@ -443,30 +374,20 @@ export function createTMDBTools(
             "Language code (e.g., 'en-US')",
           ),
         },
+        annotations: { readOnlyHint: true, openWorldHint: false },
       },
-      async (args) => {
-        try {
-          const result = args.mediaType === "movie"
-            ? await tmdbClient.getMovieGenres(config, args.language)
-            : await tmdbClient.getTVGenres(config, args.language);
+      wrapToolHandler("tmdb_get_genres", async (args) => {
+        const result = args.mediaType === "movie"
+          ? await tmdbClient.getMovieGenres(config, args.language)
+          : await tmdbClient.getTVGenres(config, args.language);
 
-          return {
-            content: [{
-              type: "text",
-              text: JSON.stringify(result, null, 2),
-            }],
-          };
-        } catch (error) {
-          return {
-            content: [{
-              type: "text",
-              text: `Error: ${
-                error instanceof Error ? error.message : String(error)
-              }`,
-            }],
-          };
-        }
-      },
+        return {
+          content: [{
+            type: "text",
+            text: JSON.stringify(result, null, 2),
+          }],
+        };
+      }),
     );
   }
 
@@ -493,34 +414,24 @@ export function createTMDBTools(
             "Language code (e.g., 'en-US')",
           ),
         },
+        annotations: { readOnlyHint: true, openWorldHint: false },
       },
-      async (args) => {
-        try {
-          const result = await tmdbClient.getTrending(
-            config,
-            args.mediaType,
-            args.timeWindow,
-            args.page,
-            args.language,
-          );
+      wrapToolHandler("tmdb_get_trending", async (args) => {
+        const result = await tmdbClient.getTrending(
+          config,
+          args.mediaType,
+          args.timeWindow,
+          args.page,
+          args.language,
+        );
 
-          return {
-            content: [{
-              type: "text",
-              text: JSON.stringify(result, null, 2),
-            }],
-          };
-        } catch (error) {
-          return {
-            content: [{
-              type: "text",
-              text: `Error: ${
-                error instanceof Error ? error.message : String(error)
-              }`,
-            }],
-          };
-        }
-      },
+        return {
+          content: [{
+            type: "text",
+            text: JSON.stringify(result, null, 2),
+          }],
+        };
+      }),
     );
   }
 
@@ -542,33 +453,23 @@ export function createTMDBTools(
             "Region for release dates (ISO 3166-1)",
           ),
         },
+        annotations: { readOnlyHint: true, openWorldHint: false },
       },
-      async (args) => {
-        try {
-          const result = await tmdbClient.getNowPlayingMovies(
-            config,
-            args.page,
-            args.language,
-            args.region,
-          );
+      wrapToolHandler("tmdb_get_now_playing_movies", async (args) => {
+        const result = await tmdbClient.getNowPlayingMovies(
+          config,
+          args.page,
+          args.language,
+          args.region,
+        );
 
-          return {
-            content: [{
-              type: "text",
-              text: JSON.stringify(result, null, 2),
-            }],
-          };
-        } catch (error) {
-          return {
-            content: [{
-              type: "text",
-              text: `Error: ${
-                error instanceof Error ? error.message : String(error)
-              }`,
-            }],
-          };
-        }
-      },
+        return {
+          content: [{
+            type: "text",
+            text: JSON.stringify(result, null, 2),
+          }],
+        };
+      }),
     );
   }
 
@@ -590,33 +491,23 @@ export function createTMDBTools(
             "Region for release dates (ISO 3166-1)",
           ),
         },
+        annotations: { readOnlyHint: true, openWorldHint: false },
       },
-      async (args) => {
-        try {
-          const result = await tmdbClient.getTopRatedMovies(
-            config,
-            args.page,
-            args.language,
-            args.region,
-          );
+      wrapToolHandler("tmdb_get_top_rated_movies", async (args) => {
+        const result = await tmdbClient.getTopRatedMovies(
+          config,
+          args.page,
+          args.language,
+          args.region,
+        );
 
-          return {
-            content: [{
-              type: "text",
-              text: JSON.stringify(result, null, 2),
-            }],
-          };
-        } catch (error) {
-          return {
-            content: [{
-              type: "text",
-              text: `Error: ${
-                error instanceof Error ? error.message : String(error)
-              }`,
-            }],
-          };
-        }
-      },
+        return {
+          content: [{
+            type: "text",
+            text: JSON.stringify(result, null, 2),
+          }],
+        };
+      }),
     );
   }
 
@@ -638,33 +529,23 @@ export function createTMDBTools(
             "Region for release dates (ISO 3166-1)",
           ),
         },
+        annotations: { readOnlyHint: true, openWorldHint: false },
       },
-      async (args) => {
-        try {
-          const result = await tmdbClient.getUpcomingMovies(
-            config,
-            args.page,
-            args.language,
-            args.region,
-          );
+      wrapToolHandler("tmdb_get_upcoming_movies", async (args) => {
+        const result = await tmdbClient.getUpcomingMovies(
+          config,
+          args.page,
+          args.language,
+          args.region,
+        );
 
-          return {
-            content: [{
-              type: "text",
-              text: JSON.stringify(result, null, 2),
-            }],
-          };
-        } catch (error) {
-          return {
-            content: [{
-              type: "text",
-              text: `Error: ${
-                error instanceof Error ? error.message : String(error)
-              }`,
-            }],
-          };
-        }
-      },
+        return {
+          content: [{
+            type: "text",
+            text: JSON.stringify(result, null, 2),
+          }],
+        };
+      }),
     );
   }
 
@@ -683,32 +564,22 @@ export function createTMDBTools(
             "Language code (e.g., 'en-US')",
           ),
         },
+        annotations: { readOnlyHint: true, openWorldHint: false },
       },
-      async (args) => {
-        try {
-          const result = await tmdbClient.getPopularTV(
-            config,
-            args.page,
-            args.language,
-          );
+      wrapToolHandler("tmdb_get_popular_tv", async (args) => {
+        const result = await tmdbClient.getPopularTV(
+          config,
+          args.page,
+          args.language,
+        );
 
-          return {
-            content: [{
-              type: "text",
-              text: JSON.stringify(result, null, 2),
-            }],
-          };
-        } catch (error) {
-          return {
-            content: [{
-              type: "text",
-              text: `Error: ${
-                error instanceof Error ? error.message : String(error)
-              }`,
-            }],
-          };
-        }
-      },
+        return {
+          content: [{
+            type: "text",
+            text: JSON.stringify(result, null, 2),
+          }],
+        };
+      }),
     );
   }
 
@@ -727,32 +598,22 @@ export function createTMDBTools(
             "Language code (e.g., 'en-US')",
           ),
         },
+        annotations: { readOnlyHint: true, openWorldHint: false },
       },
-      async (args) => {
-        try {
-          const result = await tmdbClient.getTopRatedTV(
-            config,
-            args.page,
-            args.language,
-          );
+      wrapToolHandler("tmdb_get_top_rated_tv", async (args) => {
+        const result = await tmdbClient.getTopRatedTV(
+          config,
+          args.page,
+          args.language,
+        );
 
-          return {
-            content: [{
-              type: "text",
-              text: JSON.stringify(result, null, 2),
-            }],
-          };
-        } catch (error) {
-          return {
-            content: [{
-              type: "text",
-              text: `Error: ${
-                error instanceof Error ? error.message : String(error)
-              }`,
-            }],
-          };
-        }
-      },
+        return {
+          content: [{
+            type: "text",
+            text: JSON.stringify(result, null, 2),
+          }],
+        };
+      }),
     );
   }
 
@@ -771,32 +632,22 @@ export function createTMDBTools(
             "Language code (e.g., 'en-US')",
           ),
         },
+        annotations: { readOnlyHint: true, openWorldHint: false },
       },
-      async (args) => {
-        try {
-          const result = await tmdbClient.getOnTheAirTV(
-            config,
-            args.page,
-            args.language,
-          );
+      wrapToolHandler("tmdb_get_on_the_air_tv", async (args) => {
+        const result = await tmdbClient.getOnTheAirTV(
+          config,
+          args.page,
+          args.language,
+        );
 
-          return {
-            content: [{
-              type: "text",
-              text: JSON.stringify(result, null, 2),
-            }],
-          };
-        } catch (error) {
-          return {
-            content: [{
-              type: "text",
-              text: `Error: ${
-                error instanceof Error ? error.message : String(error)
-              }`,
-            }],
-          };
-        }
-      },
+        return {
+          content: [{
+            type: "text",
+            text: JSON.stringify(result, null, 2),
+          }],
+        };
+      }),
     );
   }
 
@@ -816,33 +667,23 @@ export function createTMDBTools(
           ),
           timezone: z.string().optional().describe("Timezone for air dates"),
         },
+        annotations: { readOnlyHint: true, openWorldHint: false },
       },
-      async (args) => {
-        try {
-          const result = await tmdbClient.getAiringTodayTV(
-            config,
-            args.page,
-            args.language,
-            args.timezone,
-          );
+      wrapToolHandler("tmdb_get_airing_today_tv", async (args) => {
+        const result = await tmdbClient.getAiringTodayTV(
+          config,
+          args.page,
+          args.language,
+          args.timezone,
+        );
 
-          return {
-            content: [{
-              type: "text",
-              text: JSON.stringify(result, null, 2),
-            }],
-          };
-        } catch (error) {
-          return {
-            content: [{
-              type: "text",
-              text: `Error: ${
-                error instanceof Error ? error.message : String(error)
-              }`,
-            }],
-          };
-        }
-      },
+        return {
+          content: [{
+            type: "text",
+            text: JSON.stringify(result, null, 2),
+          }],
+        };
+      }),
     );
   }
 
@@ -862,28 +703,18 @@ export function createTMDBTools(
             "Comma-separated list of additional details to append (e.g., 'credits,videos')",
           ),
         },
+        annotations: { readOnlyHint: true, openWorldHint: false },
       },
-      async (args) => {
-        try {
-          const result = await tmdbClient.getMovieDetails(config, args.movieId);
+      wrapToolHandler("tmdb_get_movie_details", async (args) => {
+        const result = await tmdbClient.getMovieDetails(config, args.movieId);
 
-          return {
-            content: [{
-              type: "text",
-              text: JSON.stringify(result, null, 2),
-            }],
-          };
-        } catch (error) {
-          return {
-            content: [{
-              type: "text",
-              text: `Error: ${
-                error instanceof Error ? error.message : String(error)
-              }`,
-            }],
-          };
-        }
-      },
+        return {
+          content: [{
+            type: "text",
+            text: JSON.stringify(result, null, 2),
+          }],
+        };
+      }),
     );
   }
 
@@ -903,28 +734,18 @@ export function createTMDBTools(
             "Comma-separated list of additional details to append (e.g., 'credits,videos')",
           ),
         },
+        annotations: { readOnlyHint: true, openWorldHint: false },
       },
-      async (args) => {
-        try {
-          const result = await tmdbClient.getTVDetails(config, args.tvId);
+      wrapToolHandler("tmdb_get_tv_details", async (args) => {
+        const result = await tmdbClient.getTVDetails(config, args.tvId);
 
-          return {
-            content: [{
-              type: "text",
-              text: JSON.stringify(result, null, 2),
-            }],
-          };
-        } catch (error) {
-          return {
-            content: [{
-              type: "text",
-              text: `Error: ${
-                error instanceof Error ? error.message : String(error)
-              }`,
-            }],
-          };
-        }
-      },
+        return {
+          content: [{
+            type: "text",
+            text: JSON.stringify(result, null, 2),
+          }],
+        };
+      }),
     );
   }
 
@@ -944,33 +765,23 @@ export function createTMDBTools(
             "Language code (e.g., 'en-US')",
           ),
         },
+        annotations: { readOnlyHint: true, openWorldHint: false },
       },
-      async (args) => {
-        try {
-          const result = await tmdbClient.getMovieRecommendations(
-            config,
-            args.movieId,
-            args.page,
-            args.language,
-          );
+      wrapToolHandler("tmdb_get_movie_recommendations", async (args) => {
+        const result = await tmdbClient.getMovieRecommendations(
+          config,
+          args.movieId,
+          args.page,
+          args.language,
+        );
 
-          return {
-            content: [{
-              type: "text",
-              text: JSON.stringify(result, null, 2),
-            }],
-          };
-        } catch (error) {
-          return {
-            content: [{
-              type: "text",
-              text: `Error: ${
-                error instanceof Error ? error.message : String(error)
-              }`,
-            }],
-          };
-        }
-      },
+        return {
+          content: [{
+            type: "text",
+            text: JSON.stringify(result, null, 2),
+          }],
+        };
+      }),
     );
   }
 
@@ -990,33 +801,23 @@ export function createTMDBTools(
             "Language code (e.g., 'en-US')",
           ),
         },
+        annotations: { readOnlyHint: true, openWorldHint: false },
       },
-      async (args) => {
-        try {
-          const result = await tmdbClient.getTVRecommendations(
-            config,
-            args.tvId,
-            args.page,
-            args.language,
-          );
+      wrapToolHandler("tmdb_get_tv_recommendations", async (args) => {
+        const result = await tmdbClient.getTVRecommendations(
+          config,
+          args.tvId,
+          args.page,
+          args.language,
+        );
 
-          return {
-            content: [{
-              type: "text",
-              text: JSON.stringify(result, null, 2),
-            }],
-          };
-        } catch (error) {
-          return {
-            content: [{
-              type: "text",
-              text: `Error: ${
-                error instanceof Error ? error.message : String(error)
-              }`,
-            }],
-          };
-        }
-      },
+        return {
+          content: [{
+            type: "text",
+            text: JSON.stringify(result, null, 2),
+          }],
+        };
+      }),
     );
   }
 
@@ -1036,33 +837,23 @@ export function createTMDBTools(
             "Language code (e.g., 'en-US')",
           ),
         },
+        annotations: { readOnlyHint: true, openWorldHint: false },
       },
-      async (args) => {
-        try {
-          const result = await tmdbClient.getSimilarMovies(
-            config,
-            args.movieId,
-            args.page,
-            args.language,
-          );
+      wrapToolHandler("tmdb_get_similar_movies", async (args) => {
+        const result = await tmdbClient.getSimilarMovies(
+          config,
+          args.movieId,
+          args.page,
+          args.language,
+        );
 
-          return {
-            content: [{
-              type: "text",
-              text: JSON.stringify(result, null, 2),
-            }],
-          };
-        } catch (error) {
-          return {
-            content: [{
-              type: "text",
-              text: `Error: ${
-                error instanceof Error ? error.message : String(error)
-              }`,
-            }],
-          };
-        }
-      },
+        return {
+          content: [{
+            type: "text",
+            text: JSON.stringify(result, null, 2),
+          }],
+        };
+      }),
     );
   }
 
@@ -1082,33 +873,23 @@ export function createTMDBTools(
             "Language code (e.g., 'en-US')",
           ),
         },
+        annotations: { readOnlyHint: true, openWorldHint: false },
       },
-      async (args) => {
-        try {
-          const result = await tmdbClient.getSimilarTV(
-            config,
-            args.tvId,
-            args.page,
-            args.language,
-          );
+      wrapToolHandler("tmdb_get_similar_tv", async (args) => {
+        const result = await tmdbClient.getSimilarTV(
+          config,
+          args.tvId,
+          args.page,
+          args.language,
+        );
 
-          return {
-            content: [{
-              type: "text",
-              text: JSON.stringify(result, null, 2),
-            }],
-          };
-        } catch (error) {
-          return {
-            content: [{
-              type: "text",
-              text: `Error: ${
-                error instanceof Error ? error.message : String(error)
-              }`,
-            }],
-          };
-        }
-      },
+        return {
+          content: [{
+            type: "text",
+            text: JSON.stringify(result, null, 2),
+          }],
+        };
+      }),
     );
   }
 
@@ -1131,36 +912,27 @@ export function createTMDBTools(
             "Include adult content",
           ),
         },
+        annotations: { readOnlyHint: true, openWorldHint: false },
       },
-      async (args) => {
-        try {
-          const result = await tmdbClient.searchPeople(
-            config,
-            args.query,
-            args.page,
-            args.language,
-            args.include_adult,
-          );
+      wrapToolHandler("tmdb_search_people", async (args) => {
+        const result = await tmdbClient.searchPeople(
+          config,
+          args.query,
+          args.page,
+          args.language,
+          args.include_adult,
+        );
 
-          return {
-            content: [{
-              type: "text",
-              text: JSON.stringify(result, null, 2),
-            }],
-          };
-        } catch (error) {
-          return {
-            content: [{
-              type: "text",
-              text: `Error: ${
-                error instanceof Error ? error.message : String(error)
-              }`,
-            }],
-          };
-        }
-      },
+        return {
+          content: [{
+            type: "text",
+            text: JSON.stringify(result, null, 2),
+          }],
+        };
+      }),
     );
   }
+
   // tmdb_get_popular_people
   if (isToolEnabled("tmdb_get_popular_people")) {
     server.registerTool(
@@ -1176,34 +948,25 @@ export function createTMDBTools(
             "Language code (e.g., 'en-US')",
           ),
         },
+        annotations: { readOnlyHint: true, openWorldHint: false },
       },
-      async (args) => {
-        try {
-          const result = await tmdbClient.getPopularPeople(
-            config,
-            args.page,
-            args.language,
-          );
+      wrapToolHandler("tmdb_get_popular_people", async (args) => {
+        const result = await tmdbClient.getPopularPeople(
+          config,
+          args.page,
+          args.language,
+        );
 
-          return {
-            content: [{
-              type: "text",
-              text: JSON.stringify(result, null, 2),
-            }],
-          };
-        } catch (error) {
-          return {
-            content: [{
-              type: "text",
-              text: `Error: ${
-                error instanceof Error ? error.message : String(error)
-              }`,
-            }],
-          };
-        }
-      },
+        return {
+          content: [{
+            type: "text",
+            text: JSON.stringify(result, null, 2),
+          }],
+        };
+      }),
     );
   }
+
   // tmdb_get_person_details
   if (isToolEnabled("tmdb_get_person_details")) {
     server.registerTool(
@@ -1220,35 +983,26 @@ export function createTMDBTools(
             "Comma-separated list of additional details to append (e.g., 'movie_credits,tv_credits')",
           ),
         },
+        annotations: { readOnlyHint: true, openWorldHint: false },
       },
-      async (args) => {
-        try {
-          const result = await tmdbClient.getPersonDetails(
-            config,
-            args.personId,
-            args.language,
-            args.appendToResponse,
-          );
+      wrapToolHandler("tmdb_get_person_details", async (args) => {
+        const result = await tmdbClient.getPersonDetails(
+          config,
+          args.personId,
+          args.language,
+          args.appendToResponse,
+        );
 
-          return {
-            content: [{
-              type: "text",
-              text: JSON.stringify(result, null, 2),
-            }],
-          };
-        } catch (error) {
-          return {
-            content: [{
-              type: "text",
-              text: `Error: ${
-                error instanceof Error ? error.message : String(error)
-              }`,
-            }],
-          };
-        }
-      },
+        return {
+          content: [{
+            type: "text",
+            text: JSON.stringify(result, null, 2),
+          }],
+        };
+      }),
     );
   }
+
   // tmdb_get_person_movie_credits
   if (isToolEnabled("tmdb_get_person_movie_credits")) {
     server.registerTool(
@@ -1262,34 +1016,25 @@ export function createTMDBTools(
             "Language code (e.g., 'en-US')",
           ),
         },
+        annotations: { readOnlyHint: true, openWorldHint: false },
       },
-      async (args) => {
-        try {
-          const result = await tmdbClient.getPersonMovieCredits(
-            config,
-            args.personId,
-            args.language,
-          );
+      wrapToolHandler("tmdb_get_person_movie_credits", async (args) => {
+        const result = await tmdbClient.getPersonMovieCredits(
+          config,
+          args.personId,
+          args.language,
+        );
 
-          return {
-            content: [{
-              type: "text",
-              text: JSON.stringify(result, null, 2),
-            }],
-          };
-        } catch (error) {
-          return {
-            content: [{
-              type: "text",
-              text: `Error: ${
-                error instanceof Error ? error.message : String(error)
-              }`,
-            }],
-          };
-        }
-      },
+        return {
+          content: [{
+            type: "text",
+            text: JSON.stringify(result, null, 2),
+          }],
+        };
+      }),
     );
   }
+
   // tmdb_get_person_tv_credits
   if (isToolEnabled("tmdb_get_person_tv_credits")) {
     server.registerTool(
@@ -1303,34 +1048,25 @@ export function createTMDBTools(
             "Language code (e.g., 'en-US')",
           ),
         },
+        annotations: { readOnlyHint: true, openWorldHint: false },
       },
-      async (args) => {
-        try {
-          const result = await tmdbClient.getPersonTVCredits(
-            config,
-            args.personId,
-            args.language,
-          );
+      wrapToolHandler("tmdb_get_person_tv_credits", async (args) => {
+        const result = await tmdbClient.getPersonTVCredits(
+          config,
+          args.personId,
+          args.language,
+        );
 
-          return {
-            content: [{
-              type: "text",
-              text: JSON.stringify(result, null, 2),
-            }],
-          };
-        } catch (error) {
-          return {
-            content: [{
-              type: "text",
-              text: `Error: ${
-                error instanceof Error ? error.message : String(error)
-              }`,
-            }],
-          };
-        }
-      },
+        return {
+          content: [{
+            type: "text",
+            text: JSON.stringify(result, null, 2),
+          }],
+        };
+      }),
     );
   }
+
   // tmdb_search_collections
   if (isToolEnabled("tmdb_search_collections")) {
     server.registerTool(
@@ -1347,35 +1083,26 @@ export function createTMDBTools(
             "Language code (e.g., 'en-US')",
           ),
         },
+        annotations: { readOnlyHint: true, openWorldHint: false },
       },
-      async (args) => {
-        try {
-          const result = await tmdbClient.searchCollections(
-            config,
-            args.query,
-            args.page,
-            args.language,
-          );
+      wrapToolHandler("tmdb_search_collections", async (args) => {
+        const result = await tmdbClient.searchCollections(
+          config,
+          args.query,
+          args.page,
+          args.language,
+        );
 
-          return {
-            content: [{
-              type: "text",
-              text: JSON.stringify(result, null, 2),
-            }],
-          };
-        } catch (error) {
-          return {
-            content: [{
-              type: "text",
-              text: `Error: ${
-                error instanceof Error ? error.message : String(error)
-              }`,
-            }],
-          };
-        }
-      },
+        return {
+          content: [{
+            type: "text",
+            text: JSON.stringify(result, null, 2),
+          }],
+        };
+      }),
     );
   }
+
   // tmdb_get_collection_details
   if (isToolEnabled("tmdb_get_collection_details")) {
     server.registerTool(
@@ -1389,34 +1116,25 @@ export function createTMDBTools(
             "Language code (e.g., 'en-US')",
           ),
         },
+        annotations: { readOnlyHint: true, openWorldHint: false },
       },
-      async (args) => {
-        try {
-          const result = await tmdbClient.getCollectionDetails(
-            config,
-            args.collectionId,
-            args.language,
-          );
+      wrapToolHandler("tmdb_get_collection_details", async (args) => {
+        const result = await tmdbClient.getCollectionDetails(
+          config,
+          args.collectionId,
+          args.language,
+        );
 
-          return {
-            content: [{
-              type: "text",
-              text: JSON.stringify(result, null, 2),
-            }],
-          };
-        } catch (error) {
-          return {
-            content: [{
-              type: "text",
-              text: `Error: ${
-                error instanceof Error ? error.message : String(error)
-              }`,
-            }],
-          };
-        }
-      },
+        return {
+          content: [{
+            type: "text",
+            text: JSON.stringify(result, null, 2),
+          }],
+        };
+      }),
     );
   }
+
   // tmdb_search_keywords
   if (isToolEnabled("tmdb_search_keywords")) {
     server.registerTool(
@@ -1430,34 +1148,25 @@ export function createTMDBTools(
             "Page number (1-1000)",
           ),
         },
+        annotations: { readOnlyHint: true, openWorldHint: false },
       },
-      async (args) => {
-        try {
-          const result = await tmdbClient.searchKeywords(
-            config,
-            args.query,
-            args.page,
-          );
+      wrapToolHandler("tmdb_search_keywords", async (args) => {
+        const result = await tmdbClient.searchKeywords(
+          config,
+          args.query,
+          args.page,
+        );
 
-          return {
-            content: [{
-              type: "text",
-              text: JSON.stringify(result, null, 2),
-            }],
-          };
-        } catch (error) {
-          return {
-            content: [{
-              type: "text",
-              text: `Error: ${
-                error instanceof Error ? error.message : String(error)
-              }`,
-            }],
-          };
-        }
-      },
+        return {
+          content: [{
+            type: "text",
+            text: JSON.stringify(result, null, 2),
+          }],
+        };
+      }),
     );
   }
+
   // tmdb_get_movies_by_keyword
   if (isToolEnabled("tmdb_get_movies_by_keyword")) {
     server.registerTool(
@@ -1477,36 +1186,27 @@ export function createTMDBTools(
             "Include adult movies",
           ),
         },
+        annotations: { readOnlyHint: true, openWorldHint: false },
       },
-      async (args) => {
-        try {
-          const result = await tmdbClient.getMoviesByKeyword(
-            config,
-            args.keywordId,
-            args.page,
-            args.language,
-            args.include_adult,
-          );
+      wrapToolHandler("tmdb_get_movies_by_keyword", async (args) => {
+        const result = await tmdbClient.getMoviesByKeyword(
+          config,
+          args.keywordId,
+          args.page,
+          args.language,
+          args.include_adult,
+        );
 
-          return {
-            content: [{
-              type: "text",
-              text: JSON.stringify(result, null, 2),
-            }],
-          };
-        } catch (error) {
-          return {
-            content: [{
-              type: "text",
-              text: `Error: ${
-                error instanceof Error ? error.message : String(error)
-              }`,
-            }],
-          };
-        }
-      },
+        return {
+          content: [{
+            type: "text",
+            text: JSON.stringify(result, null, 2),
+          }],
+        };
+      }),
     );
   }
+
   // tmdb_get_certifications
   if (isToolEnabled("tmdb_get_certifications")) {
     server.registerTool(
@@ -1519,33 +1219,24 @@ export function createTMDBTools(
             "Media type for certifications",
           ),
         },
+        annotations: { readOnlyHint: true, openWorldHint: false },
       },
-      async (args) => {
-        try {
-          const result = await tmdbClient.getCertifications(
-            config,
-            args.mediaType,
-          );
+      wrapToolHandler("tmdb_get_certifications", async (args) => {
+        const result = await tmdbClient.getCertifications(
+          config,
+          args.mediaType,
+        );
 
-          return {
-            content: [{
-              type: "text",
-              text: JSON.stringify(result, null, 2),
-            }],
-          };
-        } catch (error) {
-          return {
-            content: [{
-              type: "text",
-              text: `Error: ${
-                error instanceof Error ? error.message : String(error)
-              }`,
-            }],
-          };
-        }
-      },
+        return {
+          content: [{
+            type: "text",
+            text: JSON.stringify(result, null, 2),
+          }],
+        };
+      }),
     );
   }
+
   // tmdb_get_watch_providers
   if (isToolEnabled("tmdb_get_watch_providers")) {
     server.registerTool(
@@ -1557,34 +1248,25 @@ export function createTMDBTools(
           mediaType: z.enum(["movie", "tv"]).describe("Media type"),
           mediaId: z.number().describe("The TMDB ID of the movie or TV show"),
         },
+        annotations: { readOnlyHint: true, openWorldHint: false },
       },
-      async (args) => {
-        try {
-          const result = await tmdbClient.getWatchProviders(
-            config,
-            args.mediaType,
-            args.mediaId,
-          );
+      wrapToolHandler("tmdb_get_watch_providers", async (args) => {
+        const result = await tmdbClient.getWatchProviders(
+          config,
+          args.mediaType,
+          args.mediaId,
+        );
 
-          return {
-            content: [{
-              type: "text",
-              text: JSON.stringify(result, null, 2),
-            }],
-          };
-        } catch (error) {
-          return {
-            content: [{
-              type: "text",
-              text: `Error: ${
-                error instanceof Error ? error.message : String(error)
-              }`,
-            }],
-          };
-        }
-      },
+        return {
+          content: [{
+            type: "text",
+            text: JSON.stringify(result, null, 2),
+          }],
+        };
+      }),
     );
   }
+
   // tmdb_get_configuration
   if (isToolEnabled("tmdb_get_configuration")) {
     server.registerTool(
@@ -1593,30 +1275,21 @@ export function createTMDBTools(
         title: "Get TMDB API configuration including image base URLs",
         description: "Get TMDB API configuration including image base URLs",
         inputSchema: {},
+        annotations: { readOnlyHint: true, openWorldHint: false },
       },
-      async () => {
-        try {
-          const result = await tmdbClient.getConfiguration(config);
+      wrapToolHandler("tmdb_get_configuration", async () => {
+        const result = await tmdbClient.getConfiguration(config);
 
-          return {
-            content: [{
-              type: "text",
-              text: JSON.stringify(result, null, 2),
-            }],
-          };
-        } catch (error) {
-          return {
-            content: [{
-              type: "text",
-              text: `Error: ${
-                error instanceof Error ? error.message : String(error)
-              }`,
-            }],
-          };
-        }
-      },
+        return {
+          content: [{
+            type: "text",
+            text: JSON.stringify(result, null, 2),
+          }],
+        };
+      }),
     );
   }
+
   // tmdb_get_countries
   if (isToolEnabled("tmdb_get_countries")) {
     server.registerTool(
@@ -1629,30 +1302,21 @@ export function createTMDBTools(
             "Language code (e.g., 'en-US')",
           ),
         },
+        annotations: { readOnlyHint: true, openWorldHint: false },
       },
-      async (args) => {
-        try {
-          const result = await tmdbClient.getCountries(config, args.language);
+      wrapToolHandler("tmdb_get_countries", async (args) => {
+        const result = await tmdbClient.getCountries(config, args.language);
 
-          return {
-            content: [{
-              type: "text",
-              text: JSON.stringify(result, null, 2),
-            }],
-          };
-        } catch (error) {
-          return {
-            content: [{
-              type: "text",
-              text: `Error: ${
-                error instanceof Error ? error.message : String(error)
-              }`,
-            }],
-          };
-        }
-      },
+        return {
+          content: [{
+            type: "text",
+            text: JSON.stringify(result, null, 2),
+          }],
+        };
+      }),
     );
   }
+
   // tmdb_get_languages
   if (isToolEnabled("tmdb_get_languages")) {
     server.registerTool(
@@ -1661,30 +1325,21 @@ export function createTMDBTools(
         title: "Get list of languages used in TMDB",
         description: "Get list of languages used in TMDB",
         inputSchema: {},
+        annotations: { readOnlyHint: true, openWorldHint: false },
       },
-      async () => {
-        try {
-          const result = await tmdbClient.getLanguages(config);
+      wrapToolHandler("tmdb_get_languages", async () => {
+        const result = await tmdbClient.getLanguages(config);
 
-          return {
-            content: [{
-              type: "text",
-              text: JSON.stringify(result, null, 2),
-            }],
-          };
-        } catch (error) {
-          return {
-            content: [{
-              type: "text",
-              text: `Error: ${
-                error instanceof Error ? error.message : String(error)
-              }`,
-            }],
-          };
-        }
-      },
+        return {
+          content: [{
+            type: "text",
+            text: JSON.stringify(result, null, 2),
+          }],
+        };
+      }),
     );
   }
+
   // tmdb_get_movie_credits
   if (isToolEnabled("tmdb_get_movie_credits")) {
     server.registerTool(
@@ -1695,30 +1350,21 @@ export function createTMDBTools(
         inputSchema: {
           movieId: z.number().describe("The TMDB movie ID"),
         },
+        annotations: { readOnlyHint: true, openWorldHint: false },
       },
-      async (args) => {
-        try {
-          const result = await tmdbClient.getMovieCredits(config, args.movieId);
+      wrapToolHandler("tmdb_get_movie_credits", async (args) => {
+        const result = await tmdbClient.getMovieCredits(config, args.movieId);
 
-          return {
-            content: [{
-              type: "text",
-              text: JSON.stringify(result, null, 2),
-            }],
-          };
-        } catch (error) {
-          return {
-            content: [{
-              type: "text",
-              text: `Error: ${
-                error instanceof Error ? error.message : String(error)
-              }`,
-            }],
-          };
-        }
-      },
+        return {
+          content: [{
+            type: "text",
+            text: JSON.stringify(result, null, 2),
+          }],
+        };
+      }),
     );
   }
+
   // tmdb_get_tv_credits
   if (isToolEnabled("tmdb_get_tv_credits")) {
     server.registerTool(
@@ -1729,28 +1375,18 @@ export function createTMDBTools(
         inputSchema: {
           tvId: z.number().describe("The TMDB TV show ID"),
         },
+        annotations: { readOnlyHint: true, openWorldHint: false },
       },
-      async (args) => {
-        try {
-          const result = await tmdbClient.getTVCredits(config, args.tvId);
+      wrapToolHandler("tmdb_get_tv_credits", async (args) => {
+        const result = await tmdbClient.getTVCredits(config, args.tvId);
 
-          return {
-            content: [{
-              type: "text",
-              text: JSON.stringify(result, null, 2),
-            }],
-          };
-        } catch (error) {
-          return {
-            content: [{
-              type: "text",
-              text: `Error: ${
-                error instanceof Error ? error.message : String(error)
-              }`,
-            }],
-          };
-        }
-      },
+        return {
+          content: [{
+            type: "text",
+            text: JSON.stringify(result, null, 2),
+          }],
+        };
+      }),
     );
   }
 }

--- a/packages/media-server-mcp/src/tools/tool-wrapper.ts
+++ b/packages/media-server-mcp/src/tools/tool-wrapper.ts
@@ -1,0 +1,50 @@
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import type { RequestHandlerExtra } from "@modelcontextprotocol/sdk/shared/protocol.js";
+import type {
+  ServerNotification,
+  ServerRequest,
+} from "@modelcontextprotocol/sdk/types.js";
+import { getLogger } from "../logging.ts";
+
+const logger = getLogger(["media-server-mcp", "tools"]);
+
+type Extra = RequestHandlerExtra<ServerRequest, ServerNotification>;
+
+/**
+ * Wraps a tool handler callback to centralize error handling, timing, and
+ * structured logging. The returned function matches the signature expected by
+ * `server.registerTool()`.
+ *
+ * On success, the original result is returned unchanged.
+ * On failure, a `CallToolResult` with `isError: true` is returned so callers
+ * always receive a well-formed response rather than an unhandled rejection.
+ */
+export function wrapToolHandler<Args>(
+  toolName: string,
+  handler: (
+    args: Args,
+    extra: Extra,
+  ) => CallToolResult | Promise<CallToolResult>,
+): (args: Args, extra: Extra) => Promise<CallToolResult> {
+  return async (args: Args, extra: Extra): Promise<CallToolResult> => {
+    const start = Date.now();
+    try {
+      const result = await handler(args, extra);
+      const durationMs = Date.now() - start;
+      logger.debug("Tool executed successfully", { toolName, durationMs });
+      return result;
+    } catch (error) {
+      const durationMs = Date.now() - start;
+      const message = error instanceof Error ? error.message : String(error);
+      logger.error("Tool execution failed", {
+        toolName,
+        durationMs,
+        error: message,
+      });
+      return {
+        isError: true,
+        content: [{ type: "text", text: `Error: ${message}` }],
+      };
+    }
+  };
+}

--- a/packages/media-server-mcp/src/transports/sse.ts
+++ b/packages/media-server-mcp/src/transports/sse.ts
@@ -19,6 +19,11 @@ export function createSSEServer(
 ): { close: () => Promise<void> } {
   const logger = getLogger(["media-server-mcp", "transport", "sse"]);
 
+  logger.warn(
+    "SSE transport is deprecated. Use Streamable HTTP (--http) instead. " +
+      "SSE will be removed in a future release.",
+  );
+
   // Store transports by session ID
   const transports = new Map<string, SSEServerTransport>();
 

--- a/packages/media-server-mcp/tests/prompts/prompts_test.ts
+++ b/packages/media-server-mcp/tests/prompts/prompts_test.ts
@@ -1,0 +1,97 @@
+import { assertEquals, assertExists } from "@std/assert";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { createRadarrConfig } from "@wyattjoh/radarr";
+import { createSonarrConfig } from "@wyattjoh/sonarr";
+import { createAddMoviePrompt } from "../../src/prompts/add-movie-prompt.ts";
+import { createAddSeriesPrompt } from "../../src/prompts/add-series-prompt.ts";
+import { createLibraryReportPrompt } from "../../src/prompts/library-report-prompt.ts";
+import { createRecommendationsPrompt } from "../../src/prompts/recommendations-prompt.ts";
+
+function makeServer(): McpServer {
+  return new McpServer(
+    { name: "test", version: "1.0.0" },
+    { capabilities: { prompts: {} } },
+  );
+}
+
+Deno.test("createAddMoviePrompt - registers without errors", () => {
+  const server = makeServer();
+  const config = createRadarrConfig("http://localhost:7878", "test-key");
+
+  // Should not throw
+  createAddMoviePrompt(server, config);
+});
+
+Deno.test("createAddSeriesPrompt - registers without errors", () => {
+  const server = makeServer();
+  const config = createSonarrConfig("http://localhost:8989", "test-key");
+
+  // Should not throw
+  createAddSeriesPrompt(server, config);
+});
+
+Deno.test("createLibraryReportPrompt - registers without errors", () => {
+  const server = makeServer();
+
+  // Should not throw
+  createLibraryReportPrompt(server);
+});
+
+Deno.test("createRecommendationsPrompt - registers without errors", () => {
+  const server = makeServer();
+
+  // Should not throw
+  createRecommendationsPrompt(server);
+});
+
+Deno.test("createLibraryReportPrompt - returns valid messages", () => {
+  const server = makeServer();
+  createLibraryReportPrompt(server);
+
+  // Access the registered prompt via the server's internal prompt registry
+  // by simulating what the SDK does: call the registered callback
+  const registered = (server as unknown as {
+    _registeredPrompts: Record<string, { callback: () => unknown }>;
+  })._registeredPrompts;
+
+  assertExists(registered, "Expected _registeredPrompts to exist on server");
+
+  const prompt = registered["library-report"];
+  assertExists(prompt, "Expected library-report prompt to be registered");
+
+  const result = (prompt.callback as () => unknown)();
+  const { messages } = result as {
+    messages: Array<{ role: string; content: { type: string; text: string } }>;
+  };
+
+  assertExists(messages, "Expected messages array");
+  assertEquals(messages.length, 1);
+  assertEquals(messages[0].role, "user");
+  assertEquals(messages[0].content.type, "text");
+  assertEquals(typeof messages[0].content.text, "string");
+});
+
+Deno.test("createRecommendationsPrompt - returns valid messages", () => {
+  const server = makeServer();
+  createRecommendationsPrompt(server);
+
+  const registered = (server as unknown as {
+    _registeredPrompts: Record<string, { callback: () => unknown }>;
+  })._registeredPrompts;
+
+  assertExists(registered);
+
+  const prompt = registered["recommendations"];
+  assertExists(prompt, "Expected recommendations prompt to be registered");
+
+  const result = (prompt.callback as () => unknown)();
+  const { messages } = result as {
+    messages: Array<{ role: string; content: { type: string; text: string } }>;
+  };
+
+  assertExists(messages);
+  assertEquals(messages.length, 1);
+  assertEquals(messages[0].role, "user");
+  assertEquals(messages[0].content.type, "text");
+  assertEquals(typeof messages[0].content.text, "string");
+});

--- a/packages/media-server-mcp/tests/resources/plex-resources_test.ts
+++ b/packages/media-server-mcp/tests/resources/plex-resources_test.ts
@@ -1,0 +1,37 @@
+import { assertEquals } from "@std/assert";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { createPlexResources } from "../../src/resources/plex-resources.ts";
+import { createPlexConfig } from "@wyattjoh/plex";
+
+Deno.test("createPlexResources - registers resources without errors", () => {
+  const server = new McpServer(
+    { name: "test", version: "1.0.0" },
+    { capabilities: { resources: {} } },
+  );
+
+  const config = createPlexConfig(
+    "http://localhost:32400",
+    "test-key",
+  );
+
+  // Should not throw
+  createPlexResources(server, config);
+});
+
+Deno.test("createPlexResources - works with valid configuration", () => {
+  const server = new McpServer(
+    { name: "test", version: "1.0.0" },
+    { capabilities: { resources: {} } },
+  );
+
+  const config = createPlexConfig(
+    "http://localhost:32400",
+    "test-key",
+  );
+
+  // Should not throw with valid configuration
+  createPlexResources(server, config);
+
+  // Test passes if no error is thrown
+  assertEquals(true, true);
+});

--- a/packages/media-server-mcp/tests/resources/radarr-resources_test.ts
+++ b/packages/media-server-mcp/tests/resources/radarr-resources_test.ts
@@ -1,0 +1,37 @@
+import { assertEquals } from "@std/assert";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { createRadarrResources } from "../../src/resources/radarr-resources.ts";
+import { createRadarrConfig } from "@wyattjoh/radarr";
+
+Deno.test("createRadarrResources - registers resources without errors", () => {
+  const server = new McpServer(
+    { name: "test", version: "1.0.0" },
+    { capabilities: { resources: {} } },
+  );
+
+  const config = createRadarrConfig(
+    "http://localhost:7878",
+    "test-key",
+  );
+
+  // Should not throw
+  createRadarrResources(server, config);
+});
+
+Deno.test("createRadarrResources - works with valid configuration", () => {
+  const server = new McpServer(
+    { name: "test", version: "1.0.0" },
+    { capabilities: { resources: {} } },
+  );
+
+  const config = createRadarrConfig(
+    "http://localhost:7878",
+    "test-key",
+  );
+
+  // Should not throw with valid configuration
+  createRadarrResources(server, config);
+
+  // Test passes if no error is thrown
+  assertEquals(true, true);
+});

--- a/packages/media-server-mcp/tests/resources/sonarr-resources_test.ts
+++ b/packages/media-server-mcp/tests/resources/sonarr-resources_test.ts
@@ -1,0 +1,37 @@
+import { assertEquals } from "@std/assert";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { createSonarrResources } from "../../src/resources/sonarr-resources.ts";
+import { createSonarrConfig } from "@wyattjoh/sonarr";
+
+Deno.test("createSonarrResources - registers resources without errors", () => {
+  const server = new McpServer(
+    { name: "test", version: "1.0.0" },
+    { capabilities: { resources: {} } },
+  );
+
+  const config = createSonarrConfig(
+    "http://localhost:8989",
+    "test-key",
+  );
+
+  // Should not throw
+  createSonarrResources(server, config);
+});
+
+Deno.test("createSonarrResources - works with valid configuration", () => {
+  const server = new McpServer(
+    { name: "test", version: "1.0.0" },
+    { capabilities: { resources: {} } },
+  );
+
+  const config = createSonarrConfig(
+    "http://localhost:8989",
+    "test-key",
+  );
+
+  // Should not throw with valid configuration
+  createSonarrResources(server, config);
+
+  // Test passes if no error is thrown
+  assertEquals(true, true);
+});

--- a/packages/media-server-mcp/tests/resources/tmdb-resources_test.ts
+++ b/packages/media-server-mcp/tests/resources/tmdb-resources_test.ts
@@ -1,0 +1,31 @@
+import { assertEquals } from "@std/assert";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { createTMDBResources } from "../../src/resources/tmdb-resources.ts";
+import { createTMDBConfig } from "@wyattjoh/tmdb";
+
+Deno.test("createTMDBResources - registers resources without errors", () => {
+  const server = new McpServer(
+    { name: "test", version: "1.0.0" },
+    { capabilities: { resources: {} } },
+  );
+
+  const config = createTMDBConfig("test-api-key");
+
+  // Should not throw
+  createTMDBResources(server, config);
+});
+
+Deno.test("createTMDBResources - works with valid configuration", () => {
+  const server = new McpServer(
+    { name: "test", version: "1.0.0" },
+    { capabilities: { resources: {} } },
+  );
+
+  const config = createTMDBConfig("test-api-key");
+
+  // Should not throw with valid configuration
+  createTMDBResources(server, config);
+
+  // Test passes if no error is thrown
+  assertEquals(true, true);
+});

--- a/packages/media-server-mcp/tests/tools/plex-tools-execution_test.ts
+++ b/packages/media-server-mcp/tests/tools/plex-tools-execution_test.ts
@@ -1,0 +1,158 @@
+import { assertEquals, assertExists } from "@std/assert";
+import { stub } from "@std/testing/mock";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { createPlexConfig } from "@wyattjoh/plex";
+import { createPlexTools } from "../../src/tools/plex-tools.ts";
+
+async function createConnectedClient(
+  server: McpServer,
+): Promise<{ client: Client; cleanup: () => Promise<void> }> {
+  const [clientTransport, serverTransport] = InMemoryTransport
+    .createLinkedPair();
+  await server.connect(serverTransport);
+  const client = new Client({ name: "test-client", version: "1.0.0" });
+  await client.connect(clientTransport);
+  return {
+    client,
+    cleanup: async () => {
+      await client.close();
+    },
+  };
+}
+
+Deno.test(
+  "plex_refresh_library - happy path returns structuredContent with message",
+  async () => {
+    // refreshLibrary returns void; Plex client returns {} for empty responses.
+    const fetchStub = stub(
+      globalThis,
+      "fetch",
+      () =>
+        Promise.resolve(
+          new Response(null, {
+            status: 200,
+          }),
+        ),
+    );
+
+    try {
+      const server = new McpServer({ name: "test", version: "1.0.0" });
+      const config = createPlexConfig(
+        "http://localhost:32400",
+        "test-plex-token",
+      );
+      createPlexTools(server, config, () => true);
+
+      const { client, cleanup } = await createConnectedClient(server);
+
+      try {
+        const result = await client.callTool({
+          name: "plex_refresh_library",
+          arguments: { key: "1" },
+        });
+
+        assertExists(result.structuredContent);
+        assertEquals(result.isError, undefined);
+
+        const structured = result.structuredContent as Record<string, unknown>;
+        assertEquals(typeof structured.message, "string");
+      } finally {
+        await cleanup();
+      }
+    } finally {
+      fetchStub.restore();
+    }
+  },
+);
+
+Deno.test(
+  "plex_remove_from_collection - happy path returns structuredContent with message",
+  async () => {
+    // removeFromCollection is a DELETE; Plex returns no body.
+    const fetchStub = stub(
+      globalThis,
+      "fetch",
+      () =>
+        Promise.resolve(
+          new Response(null, {
+            status: 200,
+          }),
+        ),
+    );
+
+    try {
+      const server = new McpServer({ name: "test", version: "1.0.0" });
+      const config = createPlexConfig(
+        "http://localhost:32400",
+        "test-plex-token",
+      );
+      createPlexTools(server, config, () => true);
+
+      const { client, cleanup } = await createConnectedClient(server);
+
+      try {
+        const result = await client.callTool({
+          name: "plex_remove_from_collection",
+          arguments: { collectionId: "42", ratingKeys: ["100"] },
+        });
+
+        assertExists(result.structuredContent);
+        assertEquals(result.isError, undefined);
+
+        const structured = result.structuredContent as Record<string, unknown>;
+        assertEquals(typeof structured.message, "string");
+      } finally {
+        await cleanup();
+      }
+    } finally {
+      fetchStub.restore();
+    }
+  },
+);
+
+Deno.test(
+  "plex_refresh_library - error path returns isError when Plex returns 500",
+  async () => {
+    const fetchStub = stub(
+      globalThis,
+      "fetch",
+      () =>
+        Promise.resolve(
+          new Response("Internal Server Error", {
+            status: 500,
+            statusText: "Internal Server Error",
+          }),
+        ),
+    );
+
+    try {
+      const server = new McpServer({ name: "test", version: "1.0.0" });
+      const config = createPlexConfig(
+        "http://localhost:32400",
+        "test-plex-token",
+      );
+      createPlexTools(server, config, () => true);
+
+      const { client, cleanup } = await createConnectedClient(server);
+
+      try {
+        const result = await client.callTool({
+          name: "plex_refresh_library",
+          arguments: { key: "1" },
+        });
+
+        assertEquals(result.isError, true);
+        assertEquals(Array.isArray(result.content), true);
+        const content = result.content as Array<{ type: string; text: string }>;
+        assertEquals(content[0].type, "text");
+        assertEquals(typeof content[0].text, "string");
+      } finally {
+        await cleanup();
+      }
+    } finally {
+      fetchStub.restore();
+    }
+  },
+);

--- a/packages/media-server-mcp/tests/tools/radarr-tools-execution_test.ts
+++ b/packages/media-server-mcp/tests/tools/radarr-tools-execution_test.ts
@@ -1,0 +1,171 @@
+import { assertEquals, assertExists } from "@std/assert";
+import { stub } from "@std/testing/mock";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { createRadarrConfig } from "@wyattjoh/radarr";
+import { createRadarrTools } from "../../src/tools/radarr-tools.ts";
+
+async function createConnectedClient(
+  server: McpServer,
+): Promise<{ client: Client; cleanup: () => Promise<void> }> {
+  const [clientTransport, serverTransport] = InMemoryTransport
+    .createLinkedPair();
+  await server.connect(serverTransport);
+  const client = new Client({ name: "test-client", version: "1.0.0" });
+  await client.connect(clientTransport);
+  return {
+    client,
+    cleanup: async () => {
+      await client.close();
+    },
+  };
+}
+
+Deno.test(
+  "radarr_search_movie - happy path returns structuredContent with paginated data",
+  async () => {
+    const mockResults = [
+      { tmdbId: 550, title: "Fight Club", year: 1999 },
+      { tmdbId: 551, title: "Fight Club 2", year: 2022 },
+    ];
+
+    const fetchStub = stub(
+      globalThis,
+      "fetch",
+      () =>
+        Promise.resolve(
+          new Response(JSON.stringify(mockResults), {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          }),
+        ),
+    );
+
+    try {
+      const server = new McpServer({ name: "test", version: "1.0.0" });
+      const config = createRadarrConfig(
+        "http://localhost:7878",
+        "test-api-key",
+      );
+      createRadarrTools(server, config, () => true);
+
+      const { client, cleanup } = await createConnectedClient(server);
+
+      try {
+        const result = await client.callTool({
+          name: "radarr_search_movie",
+          arguments: { term: "Fight Club" },
+        });
+
+        assertExists(result.structuredContent);
+        assertEquals(result.isError, undefined);
+
+        const structured = result.structuredContent as Record<string, unknown>;
+        assertEquals(structured.total, 2);
+        assertEquals(structured.returned, 2);
+        assertEquals(structured.skip, 0);
+        assertEquals(Array.isArray(structured.data), true);
+      } finally {
+        await cleanup();
+      }
+    } finally {
+      fetchStub.restore();
+    }
+  },
+);
+
+Deno.test(
+  "radarr_search_movie - error path returns isError when fetch fails",
+  async () => {
+    const fetchStub = stub(
+      globalThis,
+      "fetch",
+      () =>
+        Promise.resolve(
+          new Response("Internal Server Error", {
+            status: 500,
+            statusText: "Internal Server Error",
+          }),
+        ),
+    );
+
+    try {
+      const server = new McpServer({ name: "test", version: "1.0.0" });
+      const config = createRadarrConfig(
+        "http://localhost:7878",
+        "test-api-key",
+      );
+      createRadarrTools(server, config, () => true);
+
+      const { client, cleanup } = await createConnectedClient(server);
+
+      try {
+        const result = await client.callTool({
+          name: "radarr_search_movie",
+          arguments: { term: "Fight Club" },
+        });
+
+        assertEquals(result.isError, true);
+        assertEquals(Array.isArray(result.content), true);
+        const content = result.content as Array<{ type: string; text: string }>;
+        assertEquals(content[0].type, "text");
+        assertEquals(typeof content[0].text, "string");
+      } finally {
+        await cleanup();
+      }
+    } finally {
+      fetchStub.restore();
+    }
+  },
+);
+
+Deno.test(
+  "radarr_get_movies - happy path returns structuredContent with movie list",
+  async () => {
+    const mockMovies = [
+      { id: 1, tmdbId: 550, title: "Fight Club", year: 1999, monitored: true },
+    ];
+
+    const fetchStub = stub(
+      globalThis,
+      "fetch",
+      () =>
+        Promise.resolve(
+          new Response(JSON.stringify(mockMovies), {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          }),
+        ),
+    );
+
+    try {
+      const server = new McpServer({ name: "test", version: "1.0.0" });
+      const config = createRadarrConfig(
+        "http://localhost:7878",
+        "test-api-key",
+      );
+      createRadarrTools(server, config, () => true);
+
+      const { client, cleanup } = await createConnectedClient(server);
+
+      try {
+        const result = await client.callTool({
+          name: "radarr_get_movies",
+          arguments: {},
+        });
+
+        assertExists(result.structuredContent);
+        assertEquals(result.isError, undefined);
+
+        const structured = result.structuredContent as Record<string, unknown>;
+        assertEquals(structured.total, 1);
+        assertEquals(Array.isArray(structured.data), true);
+      } finally {
+        await cleanup();
+      }
+    } finally {
+      fetchStub.restore();
+    }
+  },
+);

--- a/packages/media-server-mcp/tests/tools/sonarr-tools-execution_test.ts
+++ b/packages/media-server-mcp/tests/tools/sonarr-tools-execution_test.ts
@@ -1,0 +1,178 @@
+import { assertEquals, assertExists } from "@std/assert";
+import { stub } from "@std/testing/mock";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { createSonarrConfig } from "@wyattjoh/sonarr";
+import { createSonarrTools } from "../../src/tools/sonarr-tools.ts";
+
+async function createConnectedClient(
+  server: McpServer,
+): Promise<{ client: Client; cleanup: () => Promise<void> }> {
+  const [clientTransport, serverTransport] = InMemoryTransport
+    .createLinkedPair();
+  await server.connect(serverTransport);
+  const client = new Client({ name: "test-client", version: "1.0.0" });
+  await client.connect(clientTransport);
+  return {
+    client,
+    cleanup: async () => {
+      await client.close();
+    },
+  };
+}
+
+Deno.test(
+  "sonarr_search_series - happy path returns structuredContent with paginated data",
+  async () => {
+    const mockResults = [
+      {
+        tvdbId: 153021,
+        title: "Breaking Bad",
+        year: 2008,
+        status: "ended",
+        seasons: [],
+      },
+    ];
+
+    const fetchStub = stub(
+      globalThis,
+      "fetch",
+      () =>
+        Promise.resolve(
+          new Response(JSON.stringify(mockResults), {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          }),
+        ),
+    );
+
+    try {
+      const server = new McpServer({ name: "test", version: "1.0.0" });
+      const config = createSonarrConfig(
+        "http://localhost:8989",
+        "test-api-key",
+      );
+      createSonarrTools(server, config, () => true);
+
+      const { client, cleanup } = await createConnectedClient(server);
+
+      try {
+        const result = await client.callTool({
+          name: "sonarr_search_series",
+          arguments: { term: "Breaking Bad" },
+        });
+
+        assertExists(result.structuredContent);
+        assertEquals(result.isError, undefined);
+
+        const structured = result.structuredContent as Record<string, unknown>;
+        assertEquals(structured.total, 1);
+        assertEquals(structured.returned, 1);
+        assertEquals(structured.skip, 0);
+        assertEquals(Array.isArray(structured.data), true);
+      } finally {
+        await cleanup();
+      }
+    } finally {
+      fetchStub.restore();
+    }
+  },
+);
+
+Deno.test(
+  "sonarr_search_series - error path returns isError when network fails",
+  async () => {
+    const fetchStub = stub(
+      globalThis,
+      "fetch",
+      () => Promise.reject(new Error("Network connection refused")),
+    );
+
+    try {
+      const server = new McpServer({ name: "test", version: "1.0.0" });
+      const config = createSonarrConfig(
+        "http://localhost:8989",
+        "test-api-key",
+      );
+      createSonarrTools(server, config, () => true);
+
+      const { client, cleanup } = await createConnectedClient(server);
+
+      try {
+        const result = await client.callTool({
+          name: "sonarr_search_series",
+          arguments: { term: "Breaking Bad" },
+        });
+
+        assertEquals(result.isError, true);
+        assertEquals(Array.isArray(result.content), true);
+        const content = result.content as Array<{ type: string; text: string }>;
+        assertEquals(content[0].type, "text");
+        assertEquals(typeof content[0].text, "string");
+      } finally {
+        await cleanup();
+      }
+    } finally {
+      fetchStub.restore();
+    }
+  },
+);
+
+Deno.test(
+  "sonarr_get_series - happy path returns structuredContent with series list",
+  async () => {
+    const mockSeries = [
+      {
+        id: 1,
+        tvdbId: 153021,
+        title: "Breaking Bad",
+        year: 2008,
+        status: "ended",
+        monitored: true,
+        seasons: [],
+      },
+    ];
+
+    const fetchStub = stub(
+      globalThis,
+      "fetch",
+      () =>
+        Promise.resolve(
+          new Response(JSON.stringify(mockSeries), {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          }),
+        ),
+    );
+
+    try {
+      const server = new McpServer({ name: "test", version: "1.0.0" });
+      const config = createSonarrConfig(
+        "http://localhost:8989",
+        "test-api-key",
+      );
+      createSonarrTools(server, config, () => true);
+
+      const { client, cleanup } = await createConnectedClient(server);
+
+      try {
+        const result = await client.callTool({
+          name: "sonarr_get_series",
+          arguments: {},
+        });
+
+        assertExists(result.structuredContent);
+        assertEquals(result.isError, undefined);
+
+        const structured = result.structuredContent as Record<string, unknown>;
+        assertEquals(structured.total, 1);
+        assertEquals(Array.isArray(structured.data), true);
+      } finally {
+        await cleanup();
+      }
+    } finally {
+      fetchStub.restore();
+    }
+  },
+);

--- a/packages/media-server-mcp/tests/tools/tmdb-tools-execution_test.ts
+++ b/packages/media-server-mcp/tests/tools/tmdb-tools-execution_test.ts
@@ -1,0 +1,180 @@
+import { assertEquals, assertExists } from "@std/assert";
+import { stub } from "@std/testing/mock";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { createTMDBConfig } from "@wyattjoh/tmdb";
+import { createTMDBTools } from "../../src/tools/tmdb-tools.ts";
+
+async function createConnectedClient(
+  server: McpServer,
+): Promise<{ client: Client; cleanup: () => Promise<void> }> {
+  const [clientTransport, serverTransport] = InMemoryTransport
+    .createLinkedPair();
+  await server.connect(serverTransport);
+  const client = new Client({ name: "test-client", version: "1.0.0" });
+  await client.connect(clientTransport);
+  return {
+    client,
+    cleanup: async () => {
+      await client.close();
+    },
+  };
+}
+
+Deno.test(
+  "tmdb_search_movies - happy path returns paginated structuredContent",
+  async () => {
+    const mockResponse = {
+      page: 1,
+      total_pages: 5,
+      total_results: 100,
+      results: [
+        { id: 550, title: "Fight Club", release_date: "1999-10-15" },
+        { id: 551, title: "Fight Club Extended", release_date: "2000-01-01" },
+      ],
+    };
+
+    const fetchStub = stub(
+      globalThis,
+      "fetch",
+      () =>
+        Promise.resolve(
+          new Response(JSON.stringify(mockResponse), {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          }),
+        ),
+    );
+
+    try {
+      const server = new McpServer({ name: "test", version: "1.0.0" });
+      const config = createTMDBConfig("test-api-key");
+      createTMDBTools(server, config, () => true);
+
+      const { client, cleanup } = await createConnectedClient(server);
+
+      try {
+        const result = await client.callTool({
+          name: "tmdb_search_movies",
+          arguments: { query: "Fight Club" },
+        });
+
+        assertExists(result.structuredContent);
+        assertEquals(result.isError, undefined);
+
+        const structured = result.structuredContent as Record<string, unknown>;
+        assertEquals(structured.page, 1);
+        assertEquals(structured.total_pages, 5);
+        assertEquals(structured.total_results, 100);
+        assertEquals(Array.isArray(structured.results), true);
+      } finally {
+        await cleanup();
+      }
+    } finally {
+      fetchStub.restore();
+    }
+  },
+);
+
+Deno.test(
+  "tmdb_search_tv - happy path returns paginated TV show structuredContent",
+  async () => {
+    const mockResponse = {
+      page: 1,
+      total_pages: 3,
+      total_results: 60,
+      results: [
+        { id: 1396, name: "Breaking Bad", first_air_date: "2008-01-20" },
+      ],
+    };
+
+    const fetchStub = stub(
+      globalThis,
+      "fetch",
+      () =>
+        Promise.resolve(
+          new Response(JSON.stringify(mockResponse), {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          }),
+        ),
+    );
+
+    try {
+      const server = new McpServer({ name: "test", version: "1.0.0" });
+      const config = createTMDBConfig("test-api-key");
+      createTMDBTools(server, config, () => true);
+
+      const { client, cleanup } = await createConnectedClient(server);
+
+      try {
+        const result = await client.callTool({
+          name: "tmdb_search_tv",
+          arguments: { query: "Breaking Bad" },
+        });
+
+        assertExists(result.structuredContent);
+        assertEquals(result.isError, undefined);
+
+        const structured = result.structuredContent as Record<string, unknown>;
+        assertEquals(structured.page, 1);
+        assertEquals(structured.total_pages, 3);
+        assertEquals(structured.total_results, 60);
+        assertEquals(Array.isArray(structured.results), true);
+      } finally {
+        await cleanup();
+      }
+    } finally {
+      fetchStub.restore();
+    }
+  },
+);
+
+Deno.test(
+  "tmdb_search_movies - error path returns isError when fetch returns 401",
+  async () => {
+    const fetchStub = stub(
+      globalThis,
+      "fetch",
+      () =>
+        Promise.resolve(
+          new Response(
+            JSON.stringify({
+              status_code: 7,
+              status_message: "Invalid API key",
+            }),
+            {
+              status: 401,
+              statusText: "Unauthorized",
+            },
+          ),
+        ),
+    );
+
+    try {
+      const server = new McpServer({ name: "test", version: "1.0.0" });
+      const config = createTMDBConfig("invalid-api-key");
+      createTMDBTools(server, config, () => true);
+
+      const { client, cleanup } = await createConnectedClient(server);
+
+      try {
+        const result = await client.callTool({
+          name: "tmdb_search_movies",
+          arguments: { query: "Fight Club" },
+        });
+
+        assertEquals(result.isError, true);
+        assertEquals(Array.isArray(result.content), true);
+        const content = result.content as Array<{ type: string; text: string }>;
+        assertEquals(content[0].type, "text");
+        assertEquals(typeof content[0].text, "string");
+      } finally {
+        await cleanup();
+      }
+    } finally {
+      fetchStub.restore();
+    }
+  },
+);

--- a/packages/media-server-mcp/tests/tools/tool-wrapper_test.ts
+++ b/packages/media-server-mcp/tests/tools/tool-wrapper_test.ts
@@ -1,0 +1,35 @@
+import { assertEquals } from "@std/assert";
+import { wrapToolHandler } from "../../src/tools/tool-wrapper.ts";
+
+Deno.test("wrapToolHandler returns handler result on success", async () => {
+  const handler = wrapToolHandler("test_tool", () => ({
+    content: [{ type: "text" as const, text: "ok" }],
+  }));
+  const result = await handler({}, {} as never);
+  assertEquals(result.content, [{ type: "text", text: "ok" }]);
+  assertEquals(result.isError, undefined);
+});
+
+Deno.test("wrapToolHandler sets isError true on thrown Error", async () => {
+  const handler = wrapToolHandler("test_tool", () => {
+    throw new Error("boom");
+  });
+  const result = await handler({}, {} as never);
+  assertEquals(result.isError, true);
+  assertEquals(result.content[0].type, "text");
+  // Verify error message is included
+  if (result.content[0].type === "text") {
+    assertEquals(result.content[0].text.includes("boom"), true);
+  }
+});
+
+Deno.test("wrapToolHandler handles non-Error throws", async () => {
+  const handler = wrapToolHandler("test_tool", () => {
+    throw "string error";
+  });
+  const result = await handler({}, {} as never);
+  assertEquals(result.isError, true);
+  if (result.content[0].type === "text") {
+    assertEquals(result.content[0].text.includes("string error"), true);
+  }
+});

--- a/packages/plex/src/client.ts
+++ b/packages/plex/src/client.ts
@@ -13,6 +13,8 @@ import {
   SearchType,
 } from "./types.ts";
 
+const REQUEST_TIMEOUT_MS = 30_000;
+
 export interface PlexConfig {
   readonly baseUrl: string;
   readonly apiKey: string;
@@ -49,6 +51,7 @@ async function makeRequest<T>(
     const response = await fetch(url, {
       ...options,
       headers,
+      signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
     });
 
     if (!response.ok) {

--- a/packages/plex/tests/timeout_test.ts
+++ b/packages/plex/tests/timeout_test.ts
@@ -1,0 +1,72 @@
+import { assert, assertEquals } from "@std/assert";
+import { createPlexConfig, testConnection } from "../mod.ts";
+
+Deno.test(
+  "makeRequest - passes AbortSignal to fetch",
+  async () => {
+    const config = createPlexConfig("http://localhost:32400", "test-token");
+    let capturedSignal: AbortSignal | undefined;
+
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = (
+      _input: string | URL | Request,
+      init?: RequestInit,
+    ): Promise<Response> => {
+      capturedSignal = init?.signal ?? undefined;
+      return Promise.resolve(
+        new Response(
+          JSON.stringify({
+            MediaContainer: { version: "1.43.0", machineIdentifier: "abc123" },
+          }),
+          {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          },
+        ),
+      );
+    };
+
+    try {
+      await testConnection(config);
+      assert(capturedSignal !== undefined, "signal should be passed to fetch");
+      assert(
+        capturedSignal instanceof AbortSignal,
+        "signal should be an AbortSignal",
+      );
+      assert(
+        !capturedSignal.aborted,
+        "signal should not be aborted for a fresh request",
+      );
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  },
+);
+
+Deno.test(
+  "makeRequest - surfaces timeout errors as failure",
+  async () => {
+    const config = createPlexConfig("http://localhost:32400", "test-token");
+
+    const originalFetch = globalThis.fetch;
+    // Simulate a timeout by throwing a DOMException with name "TimeoutError",
+    // which is what AbortSignal.timeout() causes when the deadline is exceeded.
+    globalThis.fetch = (): Promise<Response> => {
+      return Promise.reject(
+        new DOMException(
+          "The operation was aborted due to timeout",
+          "TimeoutError",
+        ),
+      );
+    };
+
+    try {
+      const result = await testConnection(config);
+      assertEquals(result.success, false);
+      assert(typeof result.error === "string");
+      assert(result.error.length > 0);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  },
+);

--- a/packages/radarr/src/client.ts
+++ b/packages/radarr/src/client.ts
@@ -17,6 +17,8 @@ import { isValidationErrorArray, ValidationException } from "./validation.ts";
 import type { SortOptions } from "./shared-types.ts";
 import { applyRadarrMovieFilters, sortRadarrMovies } from "./radarr-filters.ts";
 
+const REQUEST_TIMEOUT_MS = 30_000;
+
 export interface RadarrConfig {
   readonly baseUrl: string;
   readonly apiKey: string;
@@ -55,6 +57,7 @@ async function makeRequest<T>(
     const response = await fetch(url, {
       ...options,
       headers,
+      signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
     });
 
     if (!response.ok) {

--- a/packages/radarr/tests/timeout_test.ts
+++ b/packages/radarr/tests/timeout_test.ts
@@ -1,0 +1,67 @@
+import { assert, assertEquals } from "@std/assert";
+import { createRadarrConfig, testConnection } from "../mod.ts";
+
+Deno.test(
+  "makeRequest - passes AbortSignal to fetch",
+  async () => {
+    const config = createRadarrConfig("http://localhost:7878", "test-key");
+    let capturedSignal: AbortSignal | undefined;
+
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = (
+      _input: string | URL | Request,
+      init?: RequestInit,
+    ): Promise<Response> => {
+      capturedSignal = init?.signal ?? undefined;
+      return Promise.resolve(
+        new Response(JSON.stringify({ version: "4.0.0" }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+      );
+    };
+
+    try {
+      await testConnection(config);
+      assert(capturedSignal !== undefined, "signal should be passed to fetch");
+      assert(
+        capturedSignal instanceof AbortSignal,
+        "signal should be an AbortSignal",
+      );
+      assert(
+        !capturedSignal.aborted,
+        "signal should not be aborted for a fresh request",
+      );
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  },
+);
+
+Deno.test(
+  "makeRequest - surfaces timeout errors as failure",
+  async () => {
+    const config = createRadarrConfig("http://localhost:7878", "test-key");
+
+    const originalFetch = globalThis.fetch;
+    // Simulate a timeout by throwing a DOMException with name "TimeoutError",
+    // which is what AbortSignal.timeout() causes when the deadline is exceeded.
+    globalThis.fetch = (): Promise<Response> => {
+      return Promise.reject(
+        new DOMException(
+          "The operation was aborted due to timeout",
+          "TimeoutError",
+        ),
+      );
+    };
+
+    try {
+      const result = await testConnection(config);
+      assertEquals(result.success, false);
+      assert(typeof result.error === "string");
+      assert(result.error.length > 0);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  },
+);

--- a/packages/sonarr/src/client.ts
+++ b/packages/sonarr/src/client.ts
@@ -21,6 +21,8 @@ import {
   sortSonarrSeries,
 } from "./sonarr-filters.ts";
 
+const REQUEST_TIMEOUT_MS = 30_000;
+
 export interface SonarrConfig {
   readonly baseUrl: string;
   readonly apiKey: string;
@@ -59,6 +61,7 @@ async function makeRequest<T>(
     const response = await fetch(url, {
       ...options,
       headers,
+      signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
     });
 
     if (!response.ok) {

--- a/packages/sonarr/tests/timeout_test.ts
+++ b/packages/sonarr/tests/timeout_test.ts
@@ -1,0 +1,67 @@
+import { assert, assertEquals } from "@std/assert";
+import { createSonarrConfig, testConnection } from "../mod.ts";
+
+Deno.test(
+  "makeRequest - passes AbortSignal to fetch",
+  async () => {
+    const config = createSonarrConfig("http://localhost:8989", "test-key");
+    let capturedSignal: AbortSignal | undefined;
+
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = (
+      _input: string | URL | Request,
+      init?: RequestInit,
+    ): Promise<Response> => {
+      capturedSignal = init?.signal ?? undefined;
+      return Promise.resolve(
+        new Response(JSON.stringify({ version: "4.0.0" }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+      );
+    };
+
+    try {
+      await testConnection(config);
+      assert(capturedSignal !== undefined, "signal should be passed to fetch");
+      assert(
+        capturedSignal instanceof AbortSignal,
+        "signal should be an AbortSignal",
+      );
+      assert(
+        !capturedSignal.aborted,
+        "signal should not be aborted for a fresh request",
+      );
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  },
+);
+
+Deno.test(
+  "makeRequest - surfaces timeout errors as failure",
+  async () => {
+    const config = createSonarrConfig("http://localhost:8989", "test-key");
+
+    const originalFetch = globalThis.fetch;
+    // Simulate a timeout by throwing a DOMException with name "TimeoutError",
+    // which is what AbortSignal.timeout() causes when the deadline is exceeded.
+    globalThis.fetch = (): Promise<Response> => {
+      return Promise.reject(
+        new DOMException(
+          "The operation was aborted due to timeout",
+          "TimeoutError",
+        ),
+      );
+    };
+
+    try {
+      const result = await testConnection(config);
+      assertEquals(result.success, false);
+      assert(typeof result.error === "string");
+      assert(result.error.length > 0);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  },
+);

--- a/packages/tmdb/src/client.ts
+++ b/packages/tmdb/src/client.ts
@@ -30,6 +30,8 @@ import type {
   TMDBWatchProvidersResponse,
 } from "./types.ts";
 
+const REQUEST_TIMEOUT_MS = 30_000;
+
 export interface TMDBConfig {
   readonly baseUrl: string;
   readonly apiKey: string;
@@ -67,6 +69,7 @@ async function makeRequest<T>(
     const response = await fetch(url, {
       ...options,
       headers,
+      signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
     });
 
     if (!response.ok) {

--- a/packages/tmdb/tests/timeout_test.ts
+++ b/packages/tmdb/tests/timeout_test.ts
@@ -1,0 +1,67 @@
+import { assert, assertEquals } from "@std/assert";
+import { createTMDBConfig, testConnection } from "../mod.ts";
+
+Deno.test(
+  "makeRequest - passes AbortSignal to fetch",
+  async () => {
+    const config = createTMDBConfig("test-api-key");
+    let capturedSignal: AbortSignal | undefined;
+
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = (
+      _input: string | URL | Request,
+      init?: RequestInit,
+    ): Promise<Response> => {
+      capturedSignal = init?.signal ?? undefined;
+      return Promise.resolve(
+        new Response(JSON.stringify({ success: true }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+      );
+    };
+
+    try {
+      await testConnection(config);
+      assert(capturedSignal !== undefined, "signal should be passed to fetch");
+      assert(
+        capturedSignal instanceof AbortSignal,
+        "signal should be an AbortSignal",
+      );
+      assert(
+        !capturedSignal.aborted,
+        "signal should not be aborted for a fresh request",
+      );
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  },
+);
+
+Deno.test(
+  "makeRequest - surfaces timeout errors as failure",
+  async () => {
+    const config = createTMDBConfig("test-api-key");
+
+    const originalFetch = globalThis.fetch;
+    // Simulate a timeout by throwing a DOMException with name "TimeoutError",
+    // which is what AbortSignal.timeout() causes when the deadline is exceeded.
+    globalThis.fetch = (): Promise<Response> => {
+      return Promise.reject(
+        new DOMException(
+          "The operation was aborted due to timeout",
+          "TimeoutError",
+        ),
+      );
+    };
+
+    try {
+      const result = await testConnection(config);
+      assertEquals(result.success, false);
+      assert(typeof result.error === "string");
+      assert(result.error.length > 0);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  },
+);


### PR DESCRIPTION
## Summary

Comprehensive MCP spec adoption and architectural improvements:

- **Tool handler wrapper**: Centralized error handling via `wrapToolHandler()` that adds `isError: true` to all error responses, structured logging with timing, and eliminates duplicated try/catch blocks across all tool handlers
- **Request timeouts**: 30s `AbortSignal.timeout()` on all upstream API client fetch calls (Radarr, Sonarr, TMDB, Plex)
- **Tool annotations**: All tools annotated with `readOnlyHint`, `destructiveHint`, `idempotentHint`, and `openWorldHint` per MCP spec 2025-11-25
- **Structured output**: All tools have `outputSchema` (Zod) and return `structuredContent` for machine-readable responses
- **MCP Resources**: 9 resources exposing service configuration, genre lists, and individual item details via URI templates
- **MCP Prompts**: 4 workflow prompts (add-movie, add-series, library-report, recommendations)
- **SSE deprecation**: Warning logged on SSE transport startup directing users to Streamable HTTP
- **Test coverage**: Mocked tool execution tests, resource/prompt registration tests, timeout tests (93 total, 0 failures)

## Test plan

- [ ] `deno check` passes
- [ ] `deno fmt --check` passes
- [ ] `deno lint` passes
- [ ] `deno test --allow-net --allow-env` passes (93 passed, 0 failed)
- [ ] `deno publish --dry-run` passes for all 5 packages