### PR TITLE
feat: add Dockerfile and GHCR publish workflow

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,15 @@
+.git
+.github
+.claude
+.vscode
+.idea
+node_modules
+*.md
+!packages/**/README.md
+.env
+.env.*
+!.env.example
+tests/
+docs/
+Dockerfile
+.dockerignore

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,66 @@
+name: Docker
+
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - "@wyattjoh/media-server-mcp@v*"
+  pull_request:
+    branches:
+      - main
+    paths:
+      - "Dockerfile"
+      - ".dockerignore"
+      - ".github/workflows/docker.yml"
+      - "deno.json"
+      - "deno.lock"
+      - "packages/**"
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository_owner }}/media-server-mcp
+          # The release-please tag for the MCP package is
+          # `@wyattjoh/media-server-mcp@vX.Y.Z`. Strip the package prefix so
+          # the resulting Docker tag is the bare semver (vX.Y.Z, X.Y, etc.).
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=match,pattern=@wyattjoh/media-server-mcp@v(\d+\.\d+\.\d+),group=1
+            type=match,pattern=@wyattjoh/media-server-mcp@v(\d+\.\d+),group=1
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          platforms: linux/amd64,linux/arm64
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,29 @@
+# syntax=docker/dockerfile:1.7
+
+FROM denoland/deno:alpine-2.6.0
+
+WORKDIR /app
+
+# Copy only the files needed to resolve and cache dependencies first so
+# subsequent source-only changes don't bust the dep cache layer.
+COPY deno.json deno.lock ./
+COPY packages/plex/deno.json ./packages/plex/deno.json
+COPY packages/radarr/deno.json ./packages/radarr/deno.json
+COPY packages/sonarr/deno.json ./packages/sonarr/deno.json
+COPY packages/tmdb/deno.json ./packages/tmdb/deno.json
+COPY packages/media-server-mcp/deno.json ./packages/media-server-mcp/deno.json
+
+# Copy sources for all workspace packages.
+COPY packages/ ./packages/
+
+# Warm the module cache so cold starts don't pay the resolution cost.
+RUN deno cache packages/media-server-mcp/src/index.ts
+
+EXPOSE 3000
+
+# Streamable HTTP transport, bound to all interfaces inside the container.
+# Reverse-proxy / Tailscale serve sidecar is expected to terminate TLS.
+ENTRYPOINT ["deno", "run", \
+  "--allow-read", "--allow-write", "--allow-env", "--allow-run", "--allow-net", \
+  "packages/media-server-mcp/src/index.ts"]
+CMD ["--http", "--host", "0.0.0.0", "--port", "3000"]


### PR DESCRIPTION
## Summary

Adds a container image so the MCP server can be deployed as a Docker stack (e.g. behind a Tailscale serve sidecar) without bespoke install steps.

- `Dockerfile` — Deno-runtime image based on `denoland/deno:alpine-2.6.0`. Pre-caches workspace deps in the build layer, then runs in Streamable HTTP mode (`--http --host 0.0.0.0 --port 3000`) by default.
- `.dockerignore` — keeps `.git`, tests, docs, local env files out of the build context.
- `.github/workflows/docker.yml` — builds and pushes multi-arch (amd64 + arm64) images to `ghcr.io/wyattjoh/media-server-mcp` on:
  - pushes to `main` (`:latest` + `:main`)
  - release-please tags `@wyattjoh/media-server-mcp@vX.Y.Z` (`:X.Y.Z`, `:X.Y`)
  - PRs that touch the Dockerfile / workflow / sources (build only, no push)

## Related Issues

None — prep work for the deepthought media-server-mcp stack ([deepthought#…](https://github.com/wyattjoh/deepthought/pull/)) and the Hermes wiring ([hermes#…](https://github.com/wyattjoh/hermes/pull/)).

## Test Plan

- Image was not built locally (no Docker daemon available in the dev environment); CI is the first real build.
- Compose-side consumer (`stacks/media-server-mcp/docker-compose.yml` in deepthought) was validated with `docker compose config` and points at `ghcr.io/wyattjoh/media-server-mcp:latest`.
- Once this merges and CI publishes `:latest`, the downstream deepthought PR will pull it.

## Checklist

- [ ] `deno check` passes (no source changes)
- [ ] `deno fmt` passes (no source changes)
- [ ] `deno lint` passes (no source changes)
- [ ] `deno test --allow-net` passes (no source changes)
- [ ] README/CLAUDE.md updated (N/A — no tool/resource changes)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VjDLDFmvTGBtt6QaAQV9RL)_