### PR TITLE
Adopt MCP 2026-07-28 Stateless Protocol

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -15,5 +15,5 @@
 - [ ] `deno check` passes
 - [ ] `deno fmt` passes
 - [ ] `deno lint` passes
-- [ ] `deno test --allow-net --allow-env` passes
+- [ ] `deno task test` passes
 - [ ] README/CLAUDE.md updated (if tools or resources changed)

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -15,5 +15,5 @@
 - [ ] `deno check` passes
 - [ ] `deno fmt` passes
 - [ ] `deno lint` passes
-- [ ] `deno test --allow-net` passes
+- [ ] `deno test --allow-net --allow-env` passes
 - [ ] README/CLAUDE.md updated (if tools or resources changed)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,4 +33,4 @@ jobs:
         run: deno check
 
       - name: Run tests
-        run: deno task test
+        run: deno test --allow-net --allow-env

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,4 +33,4 @@ jobs:
         run: deno check
 
       - name: Run tests
-        run: deno test --allow-net --allow-env
+        run: deno task test

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,7 +15,7 @@ deno lint
 deno fmt
 
 # Run tests
-deno test --allow-net
+deno test --allow-net --allow-env
 
 # Development with hot reload
 deno task dev
@@ -56,7 +56,7 @@ Each package is independently publishable and has its own `deno.json` configurat
 ## Development Best Practices
 
 - Always use `deno task fmt`, `deno task lint`, and `deno task check` after modifying or creating code to ensure that it's correct.
-- Run `deno test --allow-net` to verify all tests pass before committing changes.
+- Run `deno test --allow-net --allow-env` to verify all tests pass before committing changes.
 - Tests are organized by layer: `packages/media-server-mcp/tests/` contains `tools/` (tool tests), `server_test.ts`, `auth_test.ts`, and transport tests (`sse-transport_test.ts`, `streamable-http-transport_test.ts`). Each client package also has its own `tests/` directory.
 - After changing any of the available MCP tools or resources, evaluate if you need to update the README.md and CLAUDE.md to be reflective of those changes.
 - When creating pull requests, always use the PR template at `.github/pull_request_template.md`.
@@ -164,6 +164,7 @@ PLEX_API_KEY=your-plex-api-key
 
 # Authentication Configuration (required for SSE mode, recommended for HTTP mode)
 MCP_AUTH_TOKEN=your-secure-auth-token
+MCP_ALLOWED_ORIGINS=localhost,127.0.0.1,[::1] # Browser Origin hostnames allowed in HTTP mode
 
 # Tool Configuration (all optional)
 TOOL_PROFILE=default          # Predefined profile: default, minimal, curator, maintainer, power-user, full
@@ -190,7 +191,7 @@ TOOL_CONFIG_PATH=./tools.json # Path to JSON configuration file for tool setting
 - Plex uses direct API access with `X-Plex-Token` header authentication
 - **SSE Mode Security**: SSE mode requires `MCP_AUTH_TOKEN` environment variable and validates Bearer tokens on all endpoints except `/health`
 - **SSE Deprecation**: SSE transport is deprecated. A warning is logged on startup when `--sse` is used. Prefer Streamable HTTP (`--http`) for remote deployments.
-- **Streamable HTTP Mode Security**: HTTP mode requires `MCP_AUTH_TOKEN` when binding to non-loopback addresses. When set, all endpoints except `/health` require a valid Bearer token. Localhost development (`--host 127.0.0.1`) can run without auth.
+- **Streamable HTTP Mode Security**: HTTP mode requires `MCP_AUTH_TOKEN` when binding to non-loopback addresses. When set, all endpoints except `/health` require a valid Bearer token. Localhost development (`--host 127.0.0.1`) can run without auth. Browser requests must also have a local Origin hostname or one listed in `MCP_ALLOWED_ORIGINS`; requests without `Origin` remain allowed for non-browser MCP clients.
 - **MCP 2026-07-28**: Streamable HTTP is served by `createMcpHandler()` from `@modelcontextprotocol/server`, which provides stateless modern requests and 2025-era stateless compatibility. Do not reintroduce session maps or `Mcp-Session-Id` handling. Stdio uses `serveStdio()` so it can negotiate either era. Keep `--sse` on `@modelcontextprotocol/server-legacy/sse` only as the deprecated legacy bridge.
 
 ## Available Tools by Service

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -191,6 +191,7 @@ TOOL_CONFIG_PATH=./tools.json # Path to JSON configuration file for tool setting
 - **SSE Mode Security**: SSE mode requires `MCP_AUTH_TOKEN` environment variable and validates Bearer tokens on all endpoints except `/health`
 - **SSE Deprecation**: SSE transport is deprecated. A warning is logged on startup when `--sse` is used. Prefer Streamable HTTP (`--http`) for remote deployments.
 - **Streamable HTTP Mode Security**: HTTP mode requires `MCP_AUTH_TOKEN` when binding to non-loopback addresses. When set, all endpoints except `/health` require a valid Bearer token. Localhost development (`--host 127.0.0.1`) can run without auth.
+- **MCP 2026-07-28**: Streamable HTTP is served by `createMcpHandler()` from `@modelcontextprotocol/server`, which provides stateless modern requests and 2025-era stateless compatibility. Do not reintroduce session maps or `Mcp-Session-Id` handling. Stdio uses `serveStdio()` so it can negotiate either era. Keep `--sse` on `@modelcontextprotocol/server-legacy/sse` only as the deprecated legacy bridge.
 
 ## Available Tools by Service
 
@@ -439,7 +440,7 @@ All tool files follow the same pattern:
 Example structure:
 
 ```typescript
-import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { McpServer } from "@modelcontextprotocol/server";
 import { z } from "zod";
 import { wrapToolHandler } from "../tool-wrapper.ts";
 

--- a/README.md
+++ b/README.md
@@ -223,7 +223,7 @@ curl -H "Authorization: Bearer your-secure-token" \
 
 ### Streamable HTTP Mode (Recommended for Remote)
 
-Streamable HTTP is the recommended transport for remote MCP server deployments. It uses a single `/mcp` endpoint with session management via the `Mcp-Session-Id` header, following the [MCP 2025-03-26 specification](https://modelcontextprotocol.io/specification/2025-03-26/basic/transports).
+Streamable HTTP is the recommended transport for remote MCP server deployments. It supports the stateless [MCP 2026-07-28 specification](https://modelcontextprotocol.io/specification/2026-07-28) and the SDK's 2025-era stateless compatibility path. The deprecated `--sse` mode remains available for legacy SSE clients during the transition.
 
 #### Running in Streamable HTTP Mode
 
@@ -237,9 +237,8 @@ deno run --allow-all jsr:@wyattjoh/media-server-mcp --http --port 8080 --host 12
 
 #### Endpoints
 
-- **`POST /mcp`** - Send JSON-RPC requests (Initialize creates a session; subsequent requests require `Mcp-Session-Id` header)
-- **`GET /mcp`** - Open SSE stream for server-initiated notifications (requires `Mcp-Session-Id` header)
-- **`DELETE /mcp`** - Terminate a session (requires `Mcp-Session-Id` header)
+- **`POST /mcp`** - Send JSON-RPC requests. MCP 2026-07-28 clients use `server/discover` and include matching `MCP-Protocol-Version` and `Mcp-Method` headers on every request. `tools/call`, `resources/read`, and `prompts/get` also require `Mcp-Name`.
+- **`GET /mcp`** and **`DELETE /mcp`** - Not supported by the stateless 2026-07-28 transport. Use `subscriptions/listen` for opted-in notifications.
 - **`GET /health`** - Health check endpoint (no authentication required)
 
 #### Authentication
@@ -279,7 +278,8 @@ claude mcp add --transport http media-server http://your-server:3000/mcp \
 - **Bind to specific interfaces** using `--host` to limit which network interfaces accept connections (e.g., `--host 127.0.0.1` for localhost only)
 - **Use a reverse proxy** for rate limiting, request size limits, and TLS termination
 - **Restrict network access** using firewall rules or VPN to limit who can reach the server
-- **CORS**: Both SSE and Streamable HTTP transports set `Access-Control-Allow-Origin: *` to support MCP clients across environments. Bearer tokens in `Authorization` headers are not automatically sent by browsers, but if tighter origin control is needed, configure CORS restrictions in your reverse proxy
+- **CORS**: Both SSE and Streamable HTTP transports set `Access-Control-Allow-Origin: *` to support MCP clients across environments. Bearer tokens in `Authorization` headers are not automatically sent by browsers, but if tighter origin control is needed, configure CORS restrictions in your reverse proxy.
+- **Modern HTTP headers**: Ensure reverse proxies preserve `MCP-Protocol-Version`, `Mcp-Method`, and `Mcp-Name`, because the 2026-07-28 handler validates them against each JSON-RPC request.
 
 ## Tool Configuration System
 

--- a/README.md
+++ b/README.md
@@ -786,7 +786,7 @@ deno fmt
 deno lint
 
 # Run tests
-deno test --allow-net --allow-env
+deno task test
 ```
 
 ### Project Structure

--- a/README.md
+++ b/README.md
@@ -73,6 +73,10 @@ Add to your MCP servers configuration using the JSR package:
 }
 ```
 
+## HTTP Security
+
+Streamable HTTP accepts MCP clients without an `Origin` header. Browser requests are limited to local origins (`localhost`, `127.0.0.1`, and `[::1]`) by default. Set `MCP_ALLOWED_ORIGINS` to a comma-separated list of permitted origin hostnames when serving a browser-based client behind a proxy.
+
 ## Quick Start
 
 1. **Configure at least one service** in your MCP client's configuration:
@@ -141,16 +145,17 @@ Add to your MCP servers configuration using the JSR package:
 
 ### Environment Variables
 
-| Variable         | Description                                   | Required  |
-| ---------------- | --------------------------------------------- | --------- |
-| `RADARR_URL`     | Base URL of your Radarr instance              | Optional* |
-| `RADARR_API_KEY` | API key for Radarr authentication             | Optional* |
-| `SONARR_URL`     | Base URL of your Sonarr instance              | Optional* |
-| `SONARR_API_KEY` | API key for Sonarr authentication             | Optional* |
-| `TMDB_API_KEY`   | TMDB API key for movie/TV metadata            | Optional* |
-| `PLEX_URL`       | Base URL of your Plex instance                | Optional* |
-| `PLEX_API_KEY`   | X-Plex-Token for Plex authentication          | Optional* |
-| `MCP_AUTH_TOKEN` | Authentication token for HTTP transport modes | Optional  |
+| Variable              | Description                                                   | Required  |
+| --------------------- | ------------------------------------------------------------- | --------- |
+| `RADARR_URL`          | Base URL of your Radarr instance                              | Optional* |
+| `RADARR_API_KEY`      | API key for Radarr authentication                             | Optional* |
+| `SONARR_URL`          | Base URL of your Sonarr instance                              | Optional* |
+| `SONARR_API_KEY`      | API key for Sonarr authentication                             | Optional* |
+| `TMDB_API_KEY`        | TMDB API key for movie/TV metadata                            | Optional* |
+| `PLEX_URL`            | Base URL of your Plex instance                                | Optional* |
+| `PLEX_API_KEY`        | X-Plex-Token for Plex authentication                          | Optional* |
+| `MCP_AUTH_TOKEN`      | Authentication token for HTTP transport modes                 | Optional  |
+| `MCP_ALLOWED_ORIGINS` | Comma-separated browser Origin hostnames allowed in HTTP mode | Optional  |
 
 *_At least one service (Radarr, Sonarr, TMDB, or Plex) must be configured._
 
@@ -278,7 +283,7 @@ claude mcp add --transport http media-server http://your-server:3000/mcp \
 - **Bind to specific interfaces** using `--host` to limit which network interfaces accept connections (e.g., `--host 127.0.0.1` for localhost only)
 - **Use a reverse proxy** for rate limiting, request size limits, and TLS termination
 - **Restrict network access** using firewall rules or VPN to limit who can reach the server
-- **CORS**: Both SSE and Streamable HTTP transports set `Access-Control-Allow-Origin: *` to support MCP clients across environments. Bearer tokens in `Authorization` headers are not automatically sent by browsers, but if tighter origin control is needed, configure CORS restrictions in your reverse proxy.
+- **Browser origins**: Streamable HTTP rejects browser requests unless the `Origin` hostname is local (`localhost`, `127.0.0.1`, or `[::1]`) or listed in `MCP_ALLOWED_ORIGINS`. Requests without `Origin` remain available to non-browser MCP clients. SSE retains its legacy permissive CORS behavior and requires bearer authentication.
 - **Modern HTTP headers**: Ensure reverse proxies preserve `MCP-Protocol-Version`, `Mcp-Method`, and `Mcp-Name`, because the 2026-07-28 handler validates them against each JSON-RPC request.
 
 ## Tool Configuration System
@@ -779,6 +784,9 @@ deno fmt
 
 # Linting
 deno lint
+
+# Run tests
+deno test --allow-net --allow-env
 ```
 
 ### Project Structure

--- a/deno.json
+++ b/deno.json
@@ -16,7 +16,7 @@
     "build": "deno compile --allow-read --allow-write --allow-env --allow-run --allow-net --output=packages/media-server-mcp/media-server-mcp packages/media-server-mcp/src/index.ts",
     "test": "deno test --allow-net --allow-env",
     "hooks:install": "deno run --allow-read=deno.json,.git/hooks/ --allow-write=.git/hooks/ jsr:@hongminhee/deno-task-hooks",
-    "hooks:pre-commit": "deno check && deno fmt --check && deno lint",
+    "hooks:pre-commit": "deno check packages/plex/mod.ts packages/radarr/mod.ts packages/sonarr/mod.ts packages/tmdb/mod.ts packages/media-server-mcp/src/index.ts && deno fmt --check deno.json packages && deno lint",
     "hooks:pre-push": "deno publish --dry-run --allow-dirty"
   },
   "compilerOptions": {

--- a/deno.lock
+++ b/deno.lock
@@ -9,9 +9,14 @@
     "jsr:@std/assert@1": "1.0.19",
     "jsr:@std/assert@^1.0.17": "1.0.19",
     "jsr:@std/assert@^1.0.19": "1.0.19",
+    "jsr:@std/async@^1.1.0": "1.2.0",
+    "jsr:@std/data-structures@^1.0.10": "1.0.10",
     "jsr:@std/dotenv@~0.225.6": "0.225.6",
     "jsr:@std/fmt@^1.0.9": "1.0.9",
+    "jsr:@std/fs@^1.0.22": "1.0.22",
     "jsr:@std/internal@^1.0.12": "1.0.12",
+    "jsr:@std/path@^1.1.4": "1.1.4",
+    "jsr:@std/semver@^1.0.8": "1.0.8",
     "jsr:@std/testing@^1.0.11": "1.0.17",
     "jsr:@std/text@^1.0.17": "1.0.17",
     "jsr:@wyattjoh/media-server-mcp@2.1.0": "2.1.0",
@@ -37,6 +42,7 @@
         "jsr:@cliffy/internal",
         "jsr:@cliffy/table",
         "jsr:@std/fmt",
+        "jsr:@std/semver",
         "jsr:@std/text"
       ]
     },
@@ -65,19 +71,45 @@
         "jsr:@std/internal"
       ]
     },
+    "@std/async@1.2.0": {
+      "integrity": "c059c6f6d95ca7cc012ae8e8d7164d1697113d54b0b679e4372b354b11c2dee5"
+    },
+    "@std/data-structures@1.0.10": {
+      "integrity": "f574f86b0e07c69b9edc555fcc814b57d29258bad39fd5a34ba8a80ecf033cfe"
+    },
     "@std/dotenv@0.225.6": {
       "integrity": "1d6f9db72f565bd26790fa034c26e45ecb260b5245417be76c2279e5734c421b"
     },
     "@std/fmt@1.0.9": {
       "integrity": "2487343e8899fb2be5d0e3d35013e54477ada198854e52dd05ed0422eddcabe0"
     },
+    "@std/fs@1.0.22": {
+      "integrity": "de0f277a58a867147a8a01bc1b181d0dfa80bfddba8c9cf2bacd6747bcec9308",
+      "dependencies": [
+        "jsr:@std/path"
+      ]
+    },
     "@std/internal@1.0.12": {
       "integrity": "972a634fd5bc34b242024402972cd5143eac68d8dffaca5eaa4dba30ce17b027"
+    },
+    "@std/path@1.1.4": {
+      "integrity": "1d2d43f39efb1b42f0b1882a25486647cb851481862dc7313390b2bb044314b5",
+      "dependencies": [
+        "jsr:@std/internal"
+      ]
+    },
+    "@std/semver@1.0.8": {
+      "integrity": "dc830e8b8b6a380c895d53fbfd1258dc253704ca57bbe1629ac65fd7830179b7"
     },
     "@std/testing@1.0.17": {
       "integrity": "87bdc2700fa98249d48a17cd72413352d3d3680dcfbdb64947fd0982d6bbf681",
       "dependencies": [
-        "jsr:@std/assert@^1.0.17"
+        "jsr:@std/assert@^1.0.17",
+        "jsr:@std/async",
+        "jsr:@std/data-structures",
+        "jsr:@std/fs",
+        "jsr:@std/internal",
+        "jsr:@std/path"
       ]
     },
     "@std/text@1.0.17": {

--- a/deno.lock
+++ b/deno.lock
@@ -23,9 +23,10 @@
     "jsr:@wyattjoh/sonarr@^1.1.0": "1.1.0",
     "jsr:@wyattjoh/tmdb@1.1.0": "1.1.0",
     "jsr:@wyattjoh/tmdb@^1.1.0": "1.1.0",
-    "npm:@modelcontextprotocol/sdk@*": "1.27.1_zod@4.3.6_hono@4.12.3_ajv@8.18.0_express@5.2.1",
-    "npm:@modelcontextprotocol/sdk@1.27.1": "1.27.1_zod@4.3.6_hono@4.12.3_ajv@8.18.0_express@5.2.1",
-    "npm:@modelcontextprotocol/sdk@^1.27.1": "1.27.1_zod@4.3.6_hono@4.12.3_ajv@8.18.0_express@5.2.1",
+    "npm:@modelcontextprotocol/client@2": "2.0.0",
+    "npm:@modelcontextprotocol/node@2": "2.0.0_@modelcontextprotocol+server@2.0.0_hono@4.12.9",
+    "npm:@modelcontextprotocol/server-legacy@2": "2.0.0_express@5.2.1",
+    "npm:@modelcontextprotocol/server@2": "2.0.0",
     "npm:zod@^4.3.6": "4.3.6"
   },
   "jsr": {
@@ -92,7 +93,6 @@
         "jsr:@wyattjoh/radarr@^1.1.0",
         "jsr:@wyattjoh/sonarr@^1.1.0",
         "jsr:@wyattjoh/tmdb@^1.1.0",
-        "npm:@modelcontextprotocol/sdk@^1.27.1",
         "npm:zod"
       ]
     },
@@ -122,32 +122,63 @@
     }
   },
   "npm": {
-    "@hono/node-server@1.19.9_hono@4.12.3": {
-      "integrity": "sha512-vHL6w3ecZsky+8P5MD+eFfaGTyCeOHUIFYMGpQGbrBTSmNNoxv0if69rEZ5giu36weC5saFuznL411gRX7bJDw==",
+    "@hono/node-server@1.19.11_hono@4.12.9": {
+      "integrity": "sha512-dr8/3zEaB+p0D2n/IUrlPF1HZm586qgJNXK1a9fhg/PzdtkK7Ksd5l312tJX2yBuALqDYBlG20QEbayqPyxn+g==",
       "dependencies": [
         "hono"
       ]
     },
-    "@modelcontextprotocol/sdk@1.27.1_zod@4.3.6_hono@4.12.3_ajv@8.18.0_express@5.2.1": {
-      "integrity": "sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA==",
+    "@modelcontextprotocol/client@2.0.0": {
+      "integrity": "sha512-8f1OghQ2rjzIOfqgUCP+8GiUWqRs89njoWLNqAe8kWmDePv3s1fZXseej+QXemssEuuOvLLmLO/kqM3IQHtISw==",
       "dependencies": [
-        "@hono/node-server",
-        "ajv",
-        "ajv-formats",
-        "content-type",
-        "cors",
+        "@modelcontextprotocol/core",
         "cross-spawn",
         "eventsource",
         "eventsource-parser",
+        "jose",
+        "pkce-challenge",
+        "zod"
+      ]
+    },
+    "@modelcontextprotocol/core@2.0.0": {
+      "integrity": "sha512-pJCEwGG7Lfr/+PQp9ZTwKXNeO5wzbfKL7H3MYpCorM4oFBoQrdjnBgEoqG+RjhsvS1FKrDbKux+M1HhlnGWqcA==",
+      "dependencies": [
+        "zod"
+      ]
+    },
+    "@modelcontextprotocol/node@2.0.0_@modelcontextprotocol+server@2.0.0_hono@4.12.9": {
+      "integrity": "sha512-Y4hAC2XdGDUdDOCbLDOCA4+aL3NUldjsOWlDL/YwpAxrPhRm1xHd7lZ+mLacvZ9t3PaH28wgNoaLQGrIk1P2pg==",
+      "dependencies": [
+        "@hono/node-server",
+        "@modelcontextprotocol/server",
+        "hono"
+      ],
+      "optionalPeers": [
+        "hono"
+      ]
+    },
+    "@modelcontextprotocol/server-legacy@2.0.0_express@5.2.1": {
+      "integrity": "sha512-LnffC1BSqFMHtMQxEz92lqDpHWma+ErV3ghdHDgdkCyYzVcCYKcUT5loq4kflty+Bf9C9qjJqbnphyBWyCqo8Q==",
+      "dependencies": [
+        "@modelcontextprotocol/core",
+        "content-type",
+        "cors",
         "express",
         "express-rate-limit",
-        "hono",
-        "jose",
-        "json-schema-typed",
         "pkce-challenge",
         "raw-body",
-        "zod",
-        "zod-to-json-schema"
+        "zod"
+      ],
+      "optionalPeers": [
+        "express"
+      ],
+      "deprecated": true
+    },
+    "@modelcontextprotocol/server@2.0.0": {
+      "integrity": "sha512-YhHWdHfpFMQfd0prsEnxKeS3Qz3ytIGmsS0sth4KDjnacIT7hxk6hXHkJ9KysxlkvTM+WZAtQbbcUhdoP4Hvtw==",
+      "dependencies": [
+        "@modelcontextprotocol/core",
+        "zod"
       ]
     },
     "accepts@2.0.0": {
@@ -155,24 +186,6 @@
       "dependencies": [
         "mime-types",
         "negotiator"
-      ]
-    },
-    "ajv-formats@3.0.1_ajv@8.18.0": {
-      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
-      "dependencies": [
-        "ajv"
-      ],
-      "optionalPeers": [
-        "ajv"
-      ]
-    },
-    "ajv@8.18.0": {
-      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
-      "dependencies": [
-        "fast-deep-equal",
-        "fast-uri",
-        "json-schema-traverse",
-        "require-from-string"
       ]
     },
     "body-parser@2.2.2": {
@@ -283,8 +296,8 @@
         "eventsource-parser"
       ]
     },
-    "express-rate-limit@8.2.1_express@5.2.1": {
-      "integrity": "sha512-PCZEIEIxqwhzw4KF0n7QF4QqruVTcF73O5kFKUnGOyjbCCgizBBiFaYpd/fnBLUMPw/BWw9OsiN7GgrNYr7j6g==",
+    "express-rate-limit@8.3.1_express@5.2.1": {
+      "integrity": "sha512-D1dKN+cmyPWuvB+G2SREQDzPY1agpBIcTa9sJxOPMCNeH3gwzhqJRDWCXW3gg0y//+LQ/8j52JbMROWyrKdMdw==",
       "dependencies": [
         "express",
         "ip-address"
@@ -322,12 +335,6 @@
         "type-is",
         "vary"
       ]
-    },
-    "fast-deep-equal@3.1.3": {
-      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
-    },
-    "fast-uri@3.1.0": {
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA=="
     },
     "finalhandler@2.1.1": {
       "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
@@ -383,8 +390,8 @@
         "function-bind"
       ]
     },
-    "hono@4.12.3": {
-      "integrity": "sha512-SFsVSjp8sj5UumXOOFlkZOG6XS9SJDKw0TbwFeV+AJ8xlST8kxK5Z/5EYa111UY8732lK2S/xB653ceuaoGwpg=="
+    "hono@4.12.9": {
+      "integrity": "sha512-wy3T8Zm2bsEvxKZM5w21VdHDDcwVS1yUFFY6i8UobSsKfFceT7TOwhbhfKsDyx7tYQlmRM5FLpIuYvNFyjctiA=="
     },
     "http-errors@2.0.1": {
       "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
@@ -405,8 +412,8 @@
     "inherits@2.0.4": {
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
-    "ip-address@10.0.1": {
-      "integrity": "sha512-NWv9YLW4PoW2B7xtzaS3NCot75m6nK7Icdv0o3lfMceJVRfSoQwqD4wEH5rLwoKJwUiZ/rfpiVBhnaF0FK4HoA=="
+    "ip-address@10.1.0": {
+      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q=="
     },
     "ipaddr.js@1.9.1": {
       "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="
@@ -417,14 +424,8 @@
     "isexe@2.0.0": {
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
     },
-    "jose@6.1.3": {
-      "integrity": "sha512-0TpaTfihd4QMNwrz/ob2Bp7X04yuxJkjRGi4aKmOqwhov54i6u79oCv7T+C7lo70MKH6BesI3vscD1yb/yzKXQ=="
-    },
-    "json-schema-traverse@1.0.0": {
-      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
-    },
-    "json-schema-typed@8.0.2": {
-      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA=="
+    "jose@6.2.2": {
+      "integrity": "sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ=="
     },
     "math-intrinsics@1.1.0": {
       "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="
@@ -504,9 +505,6 @@
         "iconv-lite",
         "unpipe"
       ]
-    },
-    "require-from-string@2.0.2": {
-      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="
     },
     "router@2.2.0": {
       "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
@@ -624,12 +622,6 @@
     "wrappy@1.0.2": {
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
     },
-    "zod-to-json-schema@3.25.1_zod@4.3.6": {
-      "integrity": "sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA==",
-      "dependencies": [
-        "zod"
-      ]
-    },
     "zod@4.3.6": {
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="
     }
@@ -645,7 +637,10 @@
         "dependencies": [
           "jsr:@cliffy/command@1",
           "jsr:@std/dotenv@~0.225.6",
-          "npm:@modelcontextprotocol/sdk@^1.27.1",
+          "npm:@modelcontextprotocol/client@2",
+          "npm:@modelcontextprotocol/node@2",
+          "npm:@modelcontextprotocol/server-legacy@2",
+          "npm:@modelcontextprotocol/server@2",
           "npm:zod@^4.3.6"
         ]
       }

--- a/packages/media-server-mcp/README.md
+++ b/packages/media-server-mcp/README.md
@@ -61,8 +61,9 @@ deno run --allow-all jsr:@wyattjoh/media-server-mcp --sse --port 4000
 
 The server supports the following command line options:
 
-- `--sse` - Run server in SSE (Server-Sent Events) mode over HTTP instead of stdio
-- `-p, --port <port>` - Port to run SSE server on (default: 3000)
+- `--sse` - Run the deprecated legacy SSE transport instead of stdio
+- `--http` - Run dual-era Streamable HTTP, supporting MCP 2026-07-28 and the 2025-era stateless compatibility path
+- `-p, --port <port>` - Port to run an HTTP server on (default: 3000)
 - `--help` - Show help information
 - `--version` - Show version information
 
@@ -72,10 +73,10 @@ The server supports the following command line options:
 # Run in stdio mode (default)
 deno run --allow-all jsr:@wyattjoh/media-server-mcp
 
-# Run in SSE mode on default port (3000)
-deno run --allow-all jsr:@wyattjoh/media-server-mcp --sse
+# Run in Streamable HTTP mode on the default port
+deno run --allow-all jsr:@wyattjoh/media-server-mcp --http
 
-# Run in SSE mode on custom port
+# Run the legacy SSE transport on a custom port
 deno run --allow-all jsr:@wyattjoh/media-server-mcp --sse --port 8080
 ```
 
@@ -165,13 +166,19 @@ This package uses the following client libraries:
 # Run development server (stdio mode)
 deno task dev
 
-# Run development server (SSE mode)
+# Run development server (Streamable HTTP mode)
+deno task dev:http
+
+# Run development server (legacy SSE mode)
 deno task dev:sse
 
 # Run production server (stdio mode)
 deno task start
 
-# Run production server (SSE mode)
+# Run production server (Streamable HTTP mode)
+deno task start:http
+
+# Run production server (legacy SSE mode)
 deno task start:sse
 
 # Run tests

--- a/packages/media-server-mcp/README.md
+++ b/packages/media-server-mcp/README.md
@@ -133,7 +133,8 @@ The following environment variables can be configured:
 
 ### Security Configuration
 
-- `MCP_AUTH_TOKEN` - **Required for SSE mode only** - Bearer token for HTTP authentication. Generate a secure random string for this value.
+- `MCP_AUTH_TOKEN` - Required for SSE mode and for Streamable HTTP bound to a non-loopback host. Bearer token for HTTP authentication.
+- `MCP_ALLOWED_ORIGINS` - Optional comma-separated list of browser Origin hostnames allowed in Streamable HTTP mode. Defaults to `localhost,127.0.0.1,[::1]`; requests without an `Origin` header remain allowed for non-browser MCP clients.
 
 ### Example Environment Setup
 
@@ -145,8 +146,11 @@ export SONARR_URL="http://localhost:8989"
 export SONARR_API_KEY="your-sonarr-api-key"
 export TMDB_API_KEY="your-tmdb-api-key"
 
-# Authentication token (SSE mode only)
+# Authentication token (required for SSE and remote HTTP bindings)
 export MCP_AUTH_TOKEN="$(openssl rand -base64 32)"
+
+# Optional browser clients served from non-local origins
+export MCP_ALLOWED_ORIGINS="mcp.example.com"
 
 # Run in SSE mode
 deno run --allow-all jsr:@wyattjoh/media-server-mcp --sse
@@ -182,7 +186,7 @@ deno task start:http
 deno task start:sse
 
 # Run tests
-deno test --allow-net
+deno test --allow-net --allow-env
 
 # Type check
 deno check

--- a/packages/media-server-mcp/deno.json
+++ b/packages/media-server-mcp/deno.json
@@ -19,7 +19,10 @@
     "build": "deno compile --allow-read --allow-write --allow-env --allow-run --allow-net --output=media-server-mcp src/index.ts"
   },
   "imports": {
-    "@modelcontextprotocol/sdk": "npm:@modelcontextprotocol/sdk@^1.27.1",
+    "@modelcontextprotocol/client": "npm:@modelcontextprotocol/client@^2.0.0",
+    "@modelcontextprotocol/node": "npm:@modelcontextprotocol/node@^2.0.0",
+    "@modelcontextprotocol/server": "npm:@modelcontextprotocol/server@^2.0.0",
+    "@modelcontextprotocol/server-legacy": "npm:@modelcontextprotocol/server-legacy@^2.0.0",
     "@std/dotenv": "jsr:@std/dotenv@^0.225.6",
     "zod": "npm:zod@^4.3.6",
     "@cliffy/command": "jsr:@cliffy/command@^1.0.0"

--- a/packages/media-server-mcp/src/index.ts
+++ b/packages/media-server-mcp/src/index.ts
@@ -57,6 +57,7 @@ interface ServiceConfig {
 }
 
 interface ServerState extends ServiceConfig {
+  isToolEnabled: (toolName: string) => boolean;
   transport: { close: () => Promise<void> } | undefined;
 }
 
@@ -64,9 +65,9 @@ interface ServerState extends ServiceConfig {
  * Create a new McpServer instance with tools registered based on
  * the given service configuration.
  */
-async function createMcpServerWithTools(
-  config: ServiceConfig,
-): Promise<McpServer> {
+function createMcpServerWithTools(
+  config: ServiceConfig & { isToolEnabled: (toolName: string) => boolean },
+): McpServer {
   const logger = getLogger(["media-server-mcp"]);
 
   logger.debug("Creating MCP server", {
@@ -88,7 +89,7 @@ async function createMcpServerWithTools(
     },
   );
 
-  await setupTools(server, config);
+  setupTools(server, config, config.isToolEnabled);
 
   logger.debug("Server created successfully");
   return server;
@@ -97,9 +98,13 @@ async function createMcpServerWithTools(
 async function createServer(): Promise<ServerState> {
   const config: ServiceConfig = {};
   loadConfig(config);
+  const configFileContent = await loadToolConfigFile();
+  const toolConfig = parseToolConfig(configFileContent);
+  const isToolEnabled = createToolFilter(toolConfig);
+  logToolConfiguration(toolConfig);
   await testConnections(config);
 
-  return { ...config, transport: undefined };
+  return { ...config, isToolEnabled, transport: undefined };
 }
 
 function loadConfig(state: ServiceConfig): void {
@@ -162,22 +167,13 @@ function loadConfig(state: ServiceConfig): void {
   }
 }
 
-async function setupTools(
+function setupTools(
   server: McpServer,
   config: Readonly<ServiceConfig>,
-): Promise<void> {
+  isToolEnabled: (toolName: string) => boolean,
+): void {
   const logger = getLogger(["media-server-mcp", "tools"]);
-  logger.debug("Setting up tools and filters");
-
-  // Load tool configuration from file if specified
-  const configFileContent = await loadToolConfigFile();
-
-  // Parse tool configuration
-  const toolConfig = parseToolConfig(configFileContent);
-  const isToolEnabled = createToolFilter(toolConfig);
-
-  // Log tool configuration for debugging
-  logToolConfiguration(toolConfig);
+  logger.debug("Setting up tools");
 
   // Register Radarr tools if configured
   if (config.radarrConfig) {
@@ -307,7 +303,7 @@ async function testConnections(
 
 async function runStdioServer(state: ServerState): Promise<void> {
   state.transport = await createStdioServer({
-    createMcpServer: () => createMcpServerWithTools(state),
+    createMcpServer: () => Promise.resolve(createMcpServerWithTools(state)),
   });
 }
 
@@ -325,7 +321,7 @@ function runSSEServer(
   // Start SSE server with authentication token
   state.transport = createSSEServer({
     port,
-    createMcpServer: () => createMcpServerWithTools(state),
+    createMcpServer: () => Promise.resolve(createMcpServerWithTools(state)),
     authToken: state.authToken,
   });
 }
@@ -345,11 +341,16 @@ function runStreamableHTTPServer(
     );
   }
 
+  const allowedOriginHostnames = (Deno.env.get("MCP_ALLOWED_ORIGINS") ??
+    "localhost,127.0.0.1,[::1]").split(",").map((origin) => origin.trim())
+    .filter(Boolean);
+
   state.transport = createStreamableHTTPServer({
     port,
     host,
-    createMcpServer: () => createMcpServerWithTools(state),
+    createMcpServer: () => Promise.resolve(createMcpServerWithTools(state)),
     authToken: state.authToken,
+    allowedOriginHostnames,
   });
 }
 

--- a/packages/media-server-mcp/src/index.ts
+++ b/packages/media-server-mcp/src/index.ts
@@ -3,7 +3,7 @@
 import "@std/dotenv/load";
 import process from "node:process";
 import { Command } from "@cliffy/command";
-import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { McpServer } from "@modelcontextprotocol/server";
 import deno from "../deno.json" with { type: "json" };
 import { createSSEServer } from "./transports/sse.ts";
 import { createStdioServer } from "./transports/stdio.ts";
@@ -57,8 +57,7 @@ interface ServiceConfig {
 }
 
 interface ServerState extends ServiceConfig {
-  server: McpServer;
-  transport?: { close: () => Promise<void> };
+  transport: { close: () => Promise<void> } | undefined;
 }
 
 /**
@@ -100,9 +99,7 @@ async function createServer(): Promise<ServerState> {
   loadConfig(config);
   await testConnections(config);
 
-  const server = await createMcpServerWithTools(config);
-
-  return { ...config, server };
+  return { ...config, transport: undefined };
 }
 
 function loadConfig(state: ServiceConfig): void {
@@ -222,7 +219,7 @@ async function setupTools(
     );
   }
 
-  logger.info("Tools registration completed");
+  logger.debug("Tools registration completed");
 
   // Register resources
   if (config.radarrConfig) createRadarrResources(server, config.radarrConfig);
@@ -309,7 +306,9 @@ async function testConnections(
 }
 
 async function runStdioServer(state: ServerState): Promise<void> {
-  state.transport = await createStdioServer({ server: state.server });
+  state.transport = await createStdioServer({
+    createMcpServer: () => createMcpServerWithTools(state),
+  });
 }
 
 function runSSEServer(
@@ -326,7 +325,7 @@ function runSSEServer(
   // Start SSE server with authentication token
   state.transport = createSSEServer({
     port,
-    server: state.server,
+    createMcpServer: () => createMcpServerWithTools(state),
     authToken: state.authToken,
   });
 }
@@ -365,9 +364,6 @@ function setupGracefulShutdown(state: ServerState): void {
       if (state.transport) {
         await state.transport.close();
       }
-
-      // Then close the MCP server
-      await state.server.close();
 
       logger.info("Graceful shutdown completed");
     } catch (error) {

--- a/packages/media-server-mcp/src/prompts/add-movie-prompt.ts
+++ b/packages/media-server-mcp/src/prompts/add-movie-prompt.ts
@@ -1,4 +1,4 @@
-import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { McpServer } from "@modelcontextprotocol/server";
 import type { RadarrConfig } from "@wyattjoh/radarr";
 import * as radarrClient from "@wyattjoh/radarr";
 

--- a/packages/media-server-mcp/src/prompts/add-series-prompt.ts
+++ b/packages/media-server-mcp/src/prompts/add-series-prompt.ts
@@ -1,4 +1,4 @@
-import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { McpServer } from "@modelcontextprotocol/server";
 import type { SonarrConfig } from "@wyattjoh/sonarr";
 import * as sonarrClient from "@wyattjoh/sonarr";
 

--- a/packages/media-server-mcp/src/prompts/library-report-prompt.ts
+++ b/packages/media-server-mcp/src/prompts/library-report-prompt.ts
@@ -1,4 +1,4 @@
-import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { McpServer } from "@modelcontextprotocol/server";
 
 export function createLibraryReportPrompt(server: McpServer): void {
   server.registerPrompt(

--- a/packages/media-server-mcp/src/prompts/recommendations-prompt.ts
+++ b/packages/media-server-mcp/src/prompts/recommendations-prompt.ts
@@ -1,4 +1,4 @@
-import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { McpServer } from "@modelcontextprotocol/server";
 
 export function createRecommendationsPrompt(server: McpServer): void {
   server.registerPrompt(

--- a/packages/media-server-mcp/src/resources/plex-resources.ts
+++ b/packages/media-server-mcp/src/resources/plex-resources.ts
@@ -1,5 +1,5 @@
-import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { ResourceTemplate } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { McpServer } from "@modelcontextprotocol/server";
+import { ResourceTemplate } from "@modelcontextprotocol/server";
 import type { PlexConfig } from "@wyattjoh/plex";
 import * as plexClient from "@wyattjoh/plex";
 

--- a/packages/media-server-mcp/src/resources/radarr-resources.ts
+++ b/packages/media-server-mcp/src/resources/radarr-resources.ts
@@ -1,5 +1,5 @@
-import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { ResourceTemplate } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { McpServer } from "@modelcontextprotocol/server";
+import { ResourceTemplate } from "@modelcontextprotocol/server";
 import type { RadarrConfig } from "@wyattjoh/radarr";
 import * as radarrClient from "@wyattjoh/radarr";
 

--- a/packages/media-server-mcp/src/resources/sonarr-resources.ts
+++ b/packages/media-server-mcp/src/resources/sonarr-resources.ts
@@ -1,5 +1,5 @@
-import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { ResourceTemplate } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { McpServer } from "@modelcontextprotocol/server";
+import { ResourceTemplate } from "@modelcontextprotocol/server";
 import type { SonarrConfig } from "@wyattjoh/sonarr";
 import * as sonarrClient from "@wyattjoh/sonarr";
 

--- a/packages/media-server-mcp/src/resources/tmdb-resources.ts
+++ b/packages/media-server-mcp/src/resources/tmdb-resources.ts
@@ -1,4 +1,4 @@
-import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { McpServer } from "@modelcontextprotocol/server";
 import type { TMDBConfig } from "@wyattjoh/tmdb";
 import * as tmdbClient from "@wyattjoh/tmdb";
 

--- a/packages/media-server-mcp/src/tools/plex-tools.ts
+++ b/packages/media-server-mcp/src/tools/plex-tools.ts
@@ -1,8 +1,7 @@
 import type { McpServer } from "@modelcontextprotocol/server";
 import { z } from "zod";
-import type { PlexConfig } from "@wyattjoh/plex";
+import { type PlexConfig, SearchType } from "@wyattjoh/plex";
 import * as plexClient from "@wyattjoh/plex";
-import type { SearchType } from "@wyattjoh/plex";
 import { wrapToolHandler } from "./tool-wrapper.ts";
 
 const SLIM_OMIT_KEYS = new Set([
@@ -40,7 +39,7 @@ export function createPlexTools(
             type: "text",
             text: JSON.stringify(result, null, 2),
           }],
-          structuredContent: result as unknown as Record<string, unknown>,
+          structuredContent: result,
         };
       }),
     );
@@ -64,7 +63,7 @@ export function createPlexTools(
             type: "text",
             text: JSON.stringify(result, null, 2),
           }],
-          structuredContent: result as unknown as Record<string, unknown>,
+          structuredContent: result,
         };
       }),
     );
@@ -83,9 +82,7 @@ export function createPlexTools(
           limit: z.number().optional().default(100).describe(
             "Maximum number of results to return (default: 100)",
           ),
-          searchTypes: z.array(
-            z.enum(["movies", "tv", "otherVideos", "people"]),
-          ).optional().describe(
+          searchTypes: z.array(z.enum(SearchType)).optional().describe(
             "Filter by content types. If not provided, searches all types",
           ),
         },
@@ -97,14 +94,14 @@ export function createPlexTools(
           config,
           args.query,
           args.limit,
-          args.searchTypes as SearchType[] | undefined,
+          args.searchTypes,
         );
         return {
           content: [{
             type: "text",
             text: JSON.stringify(result, null, 2),
           }],
-          structuredContent: result as unknown as Record<string, unknown>,
+          structuredContent: result,
         };
       }),
     );
@@ -133,7 +130,7 @@ export function createPlexTools(
             type: "text",
             text: JSON.stringify(result, null, 2),
           }],
-          structuredContent: result as unknown as Record<string, unknown>,
+          structuredContent: result,
         };
       }),
     );
@@ -221,7 +218,7 @@ export function createPlexTools(
             type: "text",
             text: JSON.stringify(result, slimReplacer, 2),
           }],
-          structuredContent: result as unknown as Record<string, unknown>,
+          structuredContent: result,
         };
       }),
     );
@@ -256,7 +253,7 @@ export function createPlexTools(
             type: "text",
             text: JSON.stringify(result, slimReplacer, 2),
           }],
-          structuredContent: result as unknown as Record<string, unknown>,
+          structuredContent: result,
         };
       }),
     );
@@ -287,7 +284,7 @@ export function createPlexTools(
             type: "text",
             text: JSON.stringify(result, slimReplacer, 2),
           }],
-          structuredContent: result as unknown as Record<string, unknown>,
+          structuredContent: result,
         };
       }),
     );
@@ -323,7 +320,7 @@ export function createPlexTools(
             type: "text",
             text: JSON.stringify(result, null, 2),
           }],
-          structuredContent: result as unknown as Record<string, unknown>,
+          structuredContent: result,
         };
       }),
     );

--- a/packages/media-server-mcp/src/tools/plex-tools.ts
+++ b/packages/media-server-mcp/src/tools/plex-tools.ts
@@ -1,4 +1,4 @@
-import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { McpServer } from "@modelcontextprotocol/server";
 import { z } from "zod";
 import type { PlexConfig } from "@wyattjoh/plex";
 import * as plexClient from "@wyattjoh/plex";

--- a/packages/media-server-mcp/src/tools/radarr-tools.ts
+++ b/packages/media-server-mcp/src/tools/radarr-tools.ts
@@ -1,6 +1,6 @@
 import type { McpServer } from "@modelcontextprotocol/server";
 import { z } from "zod";
-import type { RadarrConfig, RadarrMovie } from "@wyattjoh/radarr";
+import type { RadarrConfig } from "@wyattjoh/radarr";
 import * as radarrClient from "@wyattjoh/radarr";
 import { wrapToolHandler } from "./tool-wrapper.ts";
 
@@ -53,7 +53,7 @@ export function createRadarrTools(
             type: "text",
             text: JSON.stringify(results, null, 2),
           }],
-          structuredContent: results as unknown as Record<string, unknown>,
+          structuredContent: results,
         };
       }),
     );
@@ -107,7 +107,7 @@ export function createRadarrTools(
             type: "text",
             text: JSON.stringify(result, null, 2),
           }],
-          structuredContent: result as unknown as Record<string, unknown>,
+          structuredContent: result,
         };
       }),
     );
@@ -293,7 +293,7 @@ export function createRadarrTools(
             type: "text",
             text: JSON.stringify(results, null, 2),
           }],
-          structuredContent: results as unknown as Record<string, unknown>,
+          structuredContent: results,
         };
       }),
     );
@@ -358,7 +358,7 @@ export function createRadarrTools(
             type: "text",
             text: JSON.stringify(result, null, 2),
           }],
-          structuredContent: result as unknown as Record<string, unknown>,
+          structuredContent: result,
         };
       }),
     );
@@ -385,13 +385,7 @@ export function createRadarrTools(
           radarrClient.getQualityProfiles(config),
           radarrClient.getRootFolders(config),
         ]);
-        const result = {
-          qualityProfiles: qualityProfiles as unknown as Record<
-            string,
-            unknown
-          >[],
-          rootFolders: rootFolders as unknown as Record<string, unknown>[],
-        };
+        const result = { qualityProfiles, rootFolders };
         return {
           content: [{
             type: "text",
@@ -435,6 +429,16 @@ export function createRadarrTools(
         // First get the current movie data
         const currentMovie = await radarrClient.getMovie(config, args.id);
 
+        if (!currentMovie) {
+          return {
+            content: [{
+              type: "text",
+              text: `Movie ${args.id} not found`,
+            }],
+            isError: true,
+          };
+        }
+
         // Update only the specified fields
         const updatedMovie = {
           ...currentMovie,
@@ -445,7 +449,7 @@ export function createRadarrTools(
           ...(args.minimumAvailability !== undefined &&
             { minimumAvailability: args.minimumAvailability }),
           ...(args.tags !== undefined && { tags: args.tags }),
-        } as RadarrMovie;
+        };
 
         const result = await radarrClient.updateMovie(config, updatedMovie);
         return {
@@ -453,7 +457,7 @@ export function createRadarrTools(
             type: "text",
             text: JSON.stringify(result, null, 2),
           }],
-          structuredContent: result as unknown as Record<string, unknown>,
+          structuredContent: result,
         };
       }),
     );
@@ -548,7 +552,7 @@ export function createRadarrTools(
           page: results.page,
           pageSize: results.pageSize,
           totalRecords: results.totalRecords,
-          records: results.records as unknown as Record<string, unknown>[],
+          records: results.records,
         };
         return {
           content: [{ type: "text", text: JSON.stringify(results, null, 2) }],
@@ -598,7 +602,7 @@ export function createRadarrTools(
           page: results.page,
           pageSize: results.pageSize,
           totalRecords: results.totalRecords,
-          records: results.records as unknown as Record<string, unknown>[],
+          records: results.records,
         };
         return {
           content: [{ type: "text", text: JSON.stringify(results, null, 2) }],
@@ -662,7 +666,7 @@ export function createRadarrTools(
           page: results.page,
           pageSize: results.pageSize,
           totalRecords: results.totalRecords,
-          records: results.records as unknown as Record<string, unknown>[],
+          records: results.records,
         };
         return {
           content: [{ type: "text", text: JSON.stringify(results, null, 2) }],
@@ -700,7 +704,7 @@ export function createRadarrTools(
           args.includeMovie,
         );
         const structured = {
-          data: results as unknown as Record<string, unknown>[],
+          data: results,
         };
         return {
           content: [{ type: "text", text: JSON.stringify(results, null, 2) }],
@@ -740,7 +744,7 @@ export function createRadarrTools(
           args.unmonitored,
         );
         const structured = {
-          data: results as unknown as Record<string, unknown>[],
+          data: results,
         };
         return {
           content: [{ type: "text", text: JSON.stringify(results, null, 2) }],
@@ -764,7 +768,7 @@ export function createRadarrTools(
       wrapToolHandler("radarr_get_releases", async (args) => {
         const results = await radarrClient.getReleases(config, args.movieId);
         const structured = {
-          data: results as unknown as Record<string, unknown>[],
+          data: results,
         };
         return {
           content: [{ type: "text", text: JSON.stringify(results, null, 2) }],

--- a/packages/media-server-mcp/src/tools/radarr-tools.ts
+++ b/packages/media-server-mcp/src/tools/radarr-tools.ts
@@ -1,4 +1,4 @@
-import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { McpServer } from "@modelcontextprotocol/server";
 import { z } from "zod";
 import type { RadarrConfig, RadarrMovie } from "@wyattjoh/radarr";
 import * as radarrClient from "@wyattjoh/radarr";

--- a/packages/media-server-mcp/src/tools/radarr-tools.ts
+++ b/packages/media-server-mcp/src/tools/radarr-tools.ts
@@ -4,6 +4,13 @@ import type { RadarrConfig, RadarrMovie } from "@wyattjoh/radarr";
 import * as radarrClient from "@wyattjoh/radarr";
 import { wrapToolHandler } from "./tool-wrapper.ts";
 
+const RADARR_PAGINATED_HISTORY_EVENT_TYPE_IDS = {
+  grabbed: 1,
+  downloadFolderImported: 3,
+  downloadFailed: 4,
+  movieFileDeleted: 5,
+} as const;
+
 export function createRadarrTools(
   server: McpServer,
   config: Readonly<RadarrConfig>,
@@ -619,7 +626,12 @@ export function createRadarrTools(
           ),
           sortDirection: z.enum(["ascending", "descending"]).optional()
             .default("descending").describe("Sort direction"),
-          eventType: z.string().optional().describe(
+          eventType: z.enum([
+            "grabbed",
+            "downloadFolderImported",
+            "downloadFailed",
+            "movieFileDeleted",
+          ]).optional().describe(
             "Filter by event type (grabbed, downloadFolderImported, downloadFailed, movieFileDeleted)",
           ),
           includeMovie: z.boolean().optional().default(false).describe(
@@ -641,7 +653,9 @@ export function createRadarrTools(
           args.pageSize,
           args.sortKey,
           args.sortDirection,
-          args.eventType,
+          args.eventType === undefined
+            ? undefined
+            : RADARR_PAGINATED_HISTORY_EVENT_TYPE_IDS[args.eventType],
           args.includeMovie,
         );
         const structured = {

--- a/packages/media-server-mcp/src/tools/radarr-tools.ts
+++ b/packages/media-server-mcp/src/tools/radarr-tools.ts
@@ -8,7 +8,7 @@ const RADARR_PAGINATED_HISTORY_EVENT_TYPE_IDS = {
   grabbed: 1,
   downloadFolderImported: 3,
   downloadFailed: 4,
-  movieFileDeleted: 5,
+  movieFileDeleted: 6,
 } as const;
 
 export function createRadarrTools(

--- a/packages/media-server-mcp/src/tools/sonarr-tools.ts
+++ b/packages/media-server-mcp/src/tools/sonarr-tools.ts
@@ -1,4 +1,4 @@
-import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { McpServer } from "@modelcontextprotocol/server";
 import { z } from "zod";
 import type { SonarrConfig, SonarrSeries } from "@wyattjoh/sonarr";
 import * as sonarrClient from "@wyattjoh/sonarr";

--- a/packages/media-server-mcp/src/tools/sonarr-tools.ts
+++ b/packages/media-server-mcp/src/tools/sonarr-tools.ts
@@ -4,6 +4,13 @@ import type { SonarrConfig, SonarrSeries } from "@wyattjoh/sonarr";
 import * as sonarrClient from "@wyattjoh/sonarr";
 import { wrapToolHandler } from "./tool-wrapper.ts";
 
+const SONARR_PAGINATED_HISTORY_EVENT_TYPE_IDS = {
+  grabbed: 1,
+  downloadFolderImported: 3,
+  downloadFailed: 4,
+  episodeFileDeleted: 5,
+} as const;
+
 export function createSonarrTools(
   server: McpServer,
   config: Readonly<SonarrConfig>,
@@ -943,7 +950,12 @@ export function createSonarrTools(
           ),
           sortDirection: z.enum(["ascending", "descending"]).optional()
             .default("descending").describe("Sort direction"),
-          eventType: z.string().optional().describe(
+          eventType: z.enum([
+            "grabbed",
+            "downloadFolderImported",
+            "downloadFailed",
+            "episodeFileDeleted",
+          ]).optional().describe(
             "Filter by event type (grabbed, downloadFolderImported, downloadFailed, episodeFileDeleted)",
           ),
           includeSeries: z.boolean().optional().default(false).describe(
@@ -968,7 +980,9 @@ export function createSonarrTools(
           args.pageSize,
           args.sortKey,
           args.sortDirection,
-          args.eventType,
+          args.eventType === undefined
+            ? undefined
+            : SONARR_PAGINATED_HISTORY_EVENT_TYPE_IDS[args.eventType],
           args.includeSeries,
           args.includeEpisode,
         );

--- a/packages/media-server-mcp/src/tools/sonarr-tools.ts
+++ b/packages/media-server-mcp/src/tools/sonarr-tools.ts
@@ -548,10 +548,10 @@ export function createSonarrTools(
         title: "Get the download queue",
         description: "Get the download queue",
         inputSchema: {
-          limit: z.number().optional().describe(
+          limit: z.number().int().positive().optional().describe(
             "Maximum number of results to return",
           ),
-          skip: z.number().optional().describe(
+          skip: z.number().int().nonnegative().optional().describe(
             "Number of results to skip (for pagination)",
           ),
         },
@@ -565,17 +565,24 @@ export function createSonarrTools(
         annotations: { readOnlyHint: true, openWorldHint: false },
       },
       wrapToolHandler("sonarr_get_queue", async (args) => {
-        const results = await sonarrClient.getQueue(
+        const queue = await sonarrClient.getQueuePage(
           config,
           args.limit,
           args.skip,
         );
+        const structured = {
+          data: queue.records,
+          total: queue.totalRecords,
+          returned: queue.records.length,
+          skip: args.skip ?? 0,
+          limit: args.limit,
+        };
         return {
           content: [{
             type: "text",
-            text: JSON.stringify(results, null, 2),
+            text: JSON.stringify(structured, null, 2),
           }],
-          structuredContent: results as unknown as Record<string, unknown>,
+          structuredContent: structured,
         };
       }),
     );

--- a/packages/media-server-mcp/src/tools/sonarr-tools.ts
+++ b/packages/media-server-mcp/src/tools/sonarr-tools.ts
@@ -53,7 +53,7 @@ export function createSonarrTools(
             type: "text",
             text: JSON.stringify(results, null, 2),
           }],
-          structuredContent: results as unknown as Record<string, unknown>,
+          structuredContent: results,
         };
       }),
     );
@@ -121,7 +121,7 @@ export function createSonarrTools(
             type: "text",
             text: JSON.stringify(result, null, 2),
           }],
-          structuredContent: result as unknown as Record<string, unknown>,
+          structuredContent: result,
         };
       }),
     );
@@ -373,7 +373,7 @@ export function createSonarrTools(
             type: "text",
             text: JSON.stringify(results, null, 2),
           }],
-          structuredContent: results as unknown as Record<string, unknown>,
+          structuredContent: results,
         };
       }),
     );
@@ -437,7 +437,7 @@ export function createSonarrTools(
             type: "text",
             text: JSON.stringify(result, null, 2),
           }],
-          structuredContent: result as unknown as Record<string, unknown>,
+          structuredContent: result,
         };
       }),
     );
@@ -484,7 +484,7 @@ export function createSonarrTools(
             type: "text",
             text: JSON.stringify(results, null, 2),
           }],
-          structuredContent: results as unknown as Record<string, unknown>,
+          structuredContent: results,
         };
       }),
     );
@@ -541,7 +541,7 @@ export function createSonarrTools(
             type: "text",
             text: JSON.stringify(results, null, 2),
           }],
-          structuredContent: results as unknown as Record<string, unknown>,
+          structuredContent: results,
         };
       }),
     );
@@ -616,13 +616,7 @@ export function createSonarrTools(
           sonarrClient.getQualityProfiles(config),
           sonarrClient.getRootFolders(config),
         ]);
-        const result = {
-          qualityProfiles: qualityProfiles as unknown as Record<
-            string,
-            unknown
-          >[],
-          rootFolders: rootFolders as unknown as Record<string, unknown>[],
-        };
+        const result = { qualityProfiles, rootFolders };
         return {
           content: [{
             type: "text",
@@ -652,7 +646,7 @@ export function createSonarrTools(
             type: "text",
             text: JSON.stringify(result, null, 2),
           }],
-          structuredContent: result as unknown as Record<string, unknown>,
+          structuredContent: result,
         };
       }),
     );
@@ -674,7 +668,7 @@ export function createSonarrTools(
       wrapToolHandler("sonarr_get_health", async () => {
         const results = await sonarrClient.getHealth(config);
         const result = {
-          data: results as unknown as Record<string, unknown>[],
+          data: results,
         };
         return {
           content: [{
@@ -711,7 +705,7 @@ export function createSonarrTools(
             type: "text",
             text: JSON.stringify(result, null, 2),
           }],
-          structuredContent: result as unknown as Record<string, unknown>,
+          structuredContent: result,
         };
       }),
     );
@@ -737,7 +731,7 @@ export function createSonarrTools(
             type: "text",
             text: JSON.stringify(result, null, 2),
           }],
-          structuredContent: result as unknown as Record<string, unknown>,
+          structuredContent: result,
         };
       }),
     );
@@ -870,7 +864,7 @@ export function createSonarrTools(
           page: results.page,
           pageSize: results.pageSize,
           totalRecords: results.totalRecords,
-          records: results.records as unknown as Record<string, unknown>[],
+          records: results.records,
         };
         return {
           content: [{ type: "text", text: JSON.stringify(results, null, 2) }],
@@ -923,7 +917,7 @@ export function createSonarrTools(
           page: results.page,
           pageSize: results.pageSize,
           totalRecords: results.totalRecords,
-          records: results.records as unknown as Record<string, unknown>[],
+          records: results.records,
         };
         return {
           content: [{ type: "text", text: JSON.stringify(results, null, 2) }],
@@ -990,7 +984,7 @@ export function createSonarrTools(
           page: results.page,
           pageSize: results.pageSize,
           totalRecords: results.totalRecords,
-          records: results.records as unknown as Record<string, unknown>[],
+          records: results.records,
         };
         return {
           content: [{ type: "text", text: JSON.stringify(results, null, 2) }],
@@ -1035,7 +1029,7 @@ export function createSonarrTools(
           args.includeEpisode,
         );
         const structured = {
-          data: results as unknown as Record<string, unknown>[],
+          data: results,
         };
         return {
           content: [{ type: "text", text: JSON.stringify(results, null, 2) }],
@@ -1061,7 +1055,7 @@ export function createSonarrTools(
       wrapToolHandler("sonarr_get_releases", async (args) => {
         const results = await sonarrClient.getReleases(config, args.episodeId);
         const structured = {
-          data: results as unknown as Record<string, unknown>[],
+          data: results,
         };
         return {
           content: [{ type: "text", text: JSON.stringify(results, null, 2) }],

--- a/packages/media-server-mcp/src/tools/tmdb-tools.ts
+++ b/packages/media-server-mcp/src/tools/tmdb-tools.ts
@@ -49,7 +49,7 @@ export function createTMDBTools(
             type: "text",
             text: JSON.stringify(result, null, 2),
           }],
-          structuredContent: result as unknown as Record<string, unknown>,
+          structuredContent: result,
         };
       }),
     );
@@ -87,7 +87,7 @@ export function createTMDBTools(
             type: "text",
             text: JSON.stringify(result, null, 2),
           }],
-          structuredContent: result as unknown as Record<string, unknown>,
+          structuredContent: result,
         };
       }),
     );
@@ -125,7 +125,7 @@ export function createTMDBTools(
             type: "text",
             text: JSON.stringify(result, null, 2),
           }],
-          structuredContent: result as unknown as Record<string, unknown>,
+          structuredContent: result,
         };
       }),
     );
@@ -167,7 +167,7 @@ export function createTMDBTools(
             type: "text",
             text: JSON.stringify(result, null, 2),
           }],
-          structuredContent: result as unknown as Record<string, unknown>,
+          structuredContent: result,
         };
       }),
     );
@@ -203,7 +203,7 @@ export function createTMDBTools(
             type: "text",
             text: JSON.stringify(result, null, 2),
           }],
-          structuredContent: result as unknown as Record<string, unknown>,
+          structuredContent: result,
         };
       }),
     );
@@ -295,7 +295,7 @@ export function createTMDBTools(
             type: "text",
             text: JSON.stringify(result, null, 2),
           }],
-          structuredContent: result as unknown as Record<string, unknown>,
+          structuredContent: result,
         };
       }),
     );
@@ -378,7 +378,7 @@ export function createTMDBTools(
             type: "text",
             text: JSON.stringify(result, null, 2),
           }],
-          structuredContent: result as unknown as Record<string, unknown>,
+          structuredContent: result,
         };
       }),
     );
@@ -412,7 +412,7 @@ export function createTMDBTools(
             type: "text",
             text: JSON.stringify(result, null, 2),
           }],
-          structuredContent: result as unknown as Record<string, unknown>,
+          structuredContent: result,
         };
       }),
     );
@@ -458,7 +458,7 @@ export function createTMDBTools(
             type: "text",
             text: JSON.stringify(result, null, 2),
           }],
-          structuredContent: result as unknown as Record<string, unknown>,
+          structuredContent: result,
         };
       }),
     );
@@ -498,7 +498,7 @@ export function createTMDBTools(
             type: "text",
             text: JSON.stringify(result, null, 2),
           }],
-          structuredContent: result as unknown as Record<string, unknown>,
+          structuredContent: result,
         };
       }),
     );
@@ -538,7 +538,7 @@ export function createTMDBTools(
             type: "text",
             text: JSON.stringify(result, null, 2),
           }],
-          structuredContent: result as unknown as Record<string, unknown>,
+          structuredContent: result,
         };
       }),
     );
@@ -578,7 +578,7 @@ export function createTMDBTools(
             type: "text",
             text: JSON.stringify(result, null, 2),
           }],
-          structuredContent: result as unknown as Record<string, unknown>,
+          structuredContent: result,
         };
       }),
     );
@@ -614,7 +614,7 @@ export function createTMDBTools(
             type: "text",
             text: JSON.stringify(result, null, 2),
           }],
-          structuredContent: result as unknown as Record<string, unknown>,
+          structuredContent: result,
         };
       }),
     );
@@ -650,7 +650,7 @@ export function createTMDBTools(
             type: "text",
             text: JSON.stringify(result, null, 2),
           }],
-          structuredContent: result as unknown as Record<string, unknown>,
+          structuredContent: result,
         };
       }),
     );
@@ -686,7 +686,7 @@ export function createTMDBTools(
             type: "text",
             text: JSON.stringify(result, null, 2),
           }],
-          structuredContent: result as unknown as Record<string, unknown>,
+          structuredContent: result,
         };
       }),
     );
@@ -724,7 +724,7 @@ export function createTMDBTools(
             type: "text",
             text: JSON.stringify(result, null, 2),
           }],
-          structuredContent: result as unknown as Record<string, unknown>,
+          structuredContent: result,
         };
       }),
     );
@@ -757,7 +757,7 @@ export function createTMDBTools(
             type: "text",
             text: JSON.stringify(result, null, 2),
           }],
-          structuredContent: result as unknown as Record<string, unknown>,
+          structuredContent: result,
         };
       }),
     );
@@ -790,7 +790,7 @@ export function createTMDBTools(
             type: "text",
             text: JSON.stringify(result, null, 2),
           }],
-          structuredContent: result as unknown as Record<string, unknown>,
+          structuredContent: result,
         };
       }),
     );
@@ -828,7 +828,7 @@ export function createTMDBTools(
             type: "text",
             text: JSON.stringify(result, null, 2),
           }],
-          structuredContent: result as unknown as Record<string, unknown>,
+          structuredContent: result,
         };
       }),
     );
@@ -866,7 +866,7 @@ export function createTMDBTools(
             type: "text",
             text: JSON.stringify(result, null, 2),
           }],
-          structuredContent: result as unknown as Record<string, unknown>,
+          structuredContent: result,
         };
       }),
     );
@@ -904,7 +904,7 @@ export function createTMDBTools(
             type: "text",
             text: JSON.stringify(result, null, 2),
           }],
-          structuredContent: result as unknown as Record<string, unknown>,
+          structuredContent: result,
         };
       }),
     );
@@ -942,7 +942,7 @@ export function createTMDBTools(
             type: "text",
             text: JSON.stringify(result, null, 2),
           }],
-          structuredContent: result as unknown as Record<string, unknown>,
+          structuredContent: result,
         };
       }),
     );
@@ -984,7 +984,7 @@ export function createTMDBTools(
             type: "text",
             text: JSON.stringify(result, null, 2),
           }],
-          structuredContent: result as unknown as Record<string, unknown>,
+          structuredContent: result,
         };
       }),
     );
@@ -1020,7 +1020,7 @@ export function createTMDBTools(
             type: "text",
             text: JSON.stringify(result, null, 2),
           }],
-          structuredContent: result as unknown as Record<string, unknown>,
+          structuredContent: result,
         };
       }),
     );
@@ -1058,7 +1058,7 @@ export function createTMDBTools(
             type: "text",
             text: JSON.stringify(result, null, 2),
           }],
-          structuredContent: result as unknown as Record<string, unknown>,
+          structuredContent: result,
         };
       }),
     );
@@ -1095,7 +1095,7 @@ export function createTMDBTools(
             type: "text",
             text: JSON.stringify(result, null, 2),
           }],
-          structuredContent: result as unknown as Record<string, unknown>,
+          structuredContent: result,
         };
       }),
     );
@@ -1132,7 +1132,7 @@ export function createTMDBTools(
             type: "text",
             text: JSON.stringify(result, null, 2),
           }],
-          structuredContent: result as unknown as Record<string, unknown>,
+          structuredContent: result,
         };
       }),
     );
@@ -1170,7 +1170,7 @@ export function createTMDBTools(
             type: "text",
             text: JSON.stringify(result, null, 2),
           }],
-          structuredContent: result as unknown as Record<string, unknown>,
+          structuredContent: result,
         };
       }),
     );
@@ -1204,7 +1204,7 @@ export function createTMDBTools(
             type: "text",
             text: JSON.stringify(result, null, 2),
           }],
-          structuredContent: result as unknown as Record<string, unknown>,
+          structuredContent: result,
         };
       }),
     );
@@ -1238,7 +1238,7 @@ export function createTMDBTools(
             type: "text",
             text: JSON.stringify(result, null, 2),
           }],
-          structuredContent: result as unknown as Record<string, unknown>,
+          structuredContent: result,
         };
       }),
     );
@@ -1280,7 +1280,7 @@ export function createTMDBTools(
             type: "text",
             text: JSON.stringify(result, null, 2),
           }],
-          structuredContent: result as unknown as Record<string, unknown>,
+          structuredContent: result,
         };
       }),
     );
@@ -1312,7 +1312,7 @@ export function createTMDBTools(
             type: "text",
             text: JSON.stringify(result, null, 2),
           }],
-          structuredContent: result as unknown as Record<string, unknown>,
+          structuredContent: result,
         };
       }),
     );
@@ -1344,7 +1344,7 @@ export function createTMDBTools(
             type: "text",
             text: JSON.stringify(result, null, 2),
           }],
-          structuredContent: result as unknown as Record<string, unknown>,
+          structuredContent: result,
         };
       }),
     );
@@ -1369,7 +1369,7 @@ export function createTMDBTools(
             type: "text",
             text: JSON.stringify(result, null, 2),
           }],
-          structuredContent: result as unknown as Record<string, unknown>,
+          structuredContent: result,
         };
       }),
     );
@@ -1400,10 +1400,7 @@ export function createTMDBTools(
             type: "text",
             text: JSON.stringify(result, null, 2),
           }],
-          structuredContent: { countries: result } as unknown as Record<
-            string,
-            unknown
-          >,
+          structuredContent: { countries: result },
         };
       }),
     );
@@ -1430,10 +1427,7 @@ export function createTMDBTools(
             type: "text",
             text: JSON.stringify(result, null, 2),
           }],
-          structuredContent: { languages: result } as unknown as Record<
-            string,
-            unknown
-          >,
+          structuredContent: { languages: result },
         };
       }),
     );
@@ -1463,7 +1457,7 @@ export function createTMDBTools(
             type: "text",
             text: JSON.stringify(result, null, 2),
           }],
-          structuredContent: result as unknown as Record<string, unknown>,
+          structuredContent: result,
         };
       }),
     );
@@ -1493,7 +1487,7 @@ export function createTMDBTools(
             type: "text",
             text: JSON.stringify(result, null, 2),
           }],
-          structuredContent: result as unknown as Record<string, unknown>,
+          structuredContent: result,
         };
       }),
     );

--- a/packages/media-server-mcp/src/tools/tmdb-tools.ts
+++ b/packages/media-server-mcp/src/tools/tmdb-tools.ts
@@ -1,4 +1,4 @@
-import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { McpServer } from "@modelcontextprotocol/server";
 import { z } from "zod";
 import type { TMDBConfig } from "@wyattjoh/tmdb";
 import * as tmdbClient from "@wyattjoh/tmdb";

--- a/packages/media-server-mcp/src/tools/tool-filter.ts
+++ b/packages/media-server-mcp/src/tools/tool-filter.ts
@@ -166,7 +166,7 @@ export function logToolConfiguration(config: ToolFilterConfig): void {
   const logger = getLogger(["media-server-mcp", "tools"]);
   const enabledTools = getEnabledTools(config);
 
-  logger.info("Tool Configuration {*}", {
+  logger.debug("Tool Configuration {*}", {
     profile: config.profile,
     additionalBranches: config.additionalBranches,
     excludeTools: config.excludeTools,

--- a/packages/media-server-mcp/src/tools/tool-wrapper.ts
+++ b/packages/media-server-mcp/src/tools/tool-wrapper.ts
@@ -1,14 +1,12 @@
-import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
-import type { RequestHandlerExtra } from "@modelcontextprotocol/sdk/shared/protocol.js";
 import type {
-  ServerNotification,
-  ServerRequest,
-} from "@modelcontextprotocol/sdk/types.js";
+  CallToolResult,
+  ServerContext,
+} from "@modelcontextprotocol/server";
 import { getLogger } from "../logging.ts";
 
 const logger = getLogger(["media-server-mcp", "tools"]);
 
-type Extra = RequestHandlerExtra<ServerRequest, ServerNotification>;
+type Extra = ServerContext;
 
 /**
  * Wraps a tool handler callback to centralize error handling, timing, and
@@ -27,6 +25,7 @@ export function wrapToolHandler<Args>(
   ) => CallToolResult | Promise<CallToolResult>,
 ): (args: Args, extra: Extra) => Promise<CallToolResult> {
   return async (args: Args, extra: Extra): Promise<CallToolResult> => {
+    logger.info("Tool called: {toolName}", { toolName });
     const start = Date.now();
     try {
       const result = await handler(args, extra);

--- a/packages/media-server-mcp/src/tools/tool-wrapper.ts
+++ b/packages/media-server-mcp/src/tools/tool-wrapper.ts
@@ -25,7 +25,7 @@ export function wrapToolHandler<Args>(
   ) => CallToolResult | Promise<CallToolResult>,
 ): (args: Args, extra: Extra) => Promise<CallToolResult> {
   return async (args: Args, extra: Extra): Promise<CallToolResult> => {
-    logger.info("Tool called: {toolName}", { toolName });
+    logger.debug("Tool called: {toolName}", { toolName });
     const start = Date.now();
     try {
       const result = await handler(args, extra);

--- a/packages/media-server-mcp/src/transports/shared.ts
+++ b/packages/media-server-mcp/src/transports/shared.ts
@@ -22,7 +22,9 @@ export function setCorsHeaders(
   res.setHeader("Access-Control-Allow-Origin", "*");
   res.setHeader("Access-Control-Allow-Methods", methods);
   res.setHeader("Access-Control-Allow-Headers", allowHeaders);
-  res.setHeader("Access-Control-Expose-Headers", exposeHeaders);
+  if (exposeHeaders) {
+    res.setHeader("Access-Control-Expose-Headers", exposeHeaders);
+  }
 }
 
 /**
@@ -78,9 +80,15 @@ export async function readBody(
  *
  * Accepts any iterable of [sessionId, closeable] entries so callers
  * don't need to build an intermediate Map.
+ *
+ * @param entries - Session IDs paired with synchronous or asynchronous closeables.
+ * @param httpServer - Node HTTP server to close after session teardown.
+ * @param logger - Transport logger used for structured cleanup failures.
+ * @param serverName - Human-readable server name used in lifecycle logs.
+ * @returns A promise that settles after closeables and the HTTP server settle.
  */
-export function closeTransportServer(
-  entries: Iterable<[string, { close: () => void }]>,
+export async function closeTransportServer(
+  entries: Iterable<[string, { close: () => void | Promise<void> }]>,
   httpServer: Server,
   logger: ReturnType<typeof getLogger>,
   serverName: string,
@@ -89,7 +97,7 @@ export function closeTransportServer(
 
   for (const [sessionId, transport] of entries) {
     try {
-      transport.close();
+      await transport.close();
     } catch (error) {
       logger.error(
         "Error closing transport for session {sessionId}",

--- a/packages/media-server-mcp/src/transports/sse.ts
+++ b/packages/media-server-mcp/src/transports/sse.ts
@@ -129,11 +129,7 @@ export function createSSEServer(
           return;
         }
 
-        await transport.handlePostMessage(
-          req,
-          res,
-          body as Record<string, unknown>,
-        );
+        await transport.handlePostMessage(req, res, body);
       } else if (pathname === "/health") {
         // Health check endpoint
         res.writeHead(200, { "Content-Type": "application/json" });

--- a/packages/media-server-mcp/src/transports/sse.ts
+++ b/packages/media-server-mcp/src/transports/sse.ts
@@ -14,9 +14,21 @@ interface SSEServerOptions {
   authToken: string;
 }
 
+interface SSEServerHandle {
+  ready: Promise<void>;
+  port: () => number;
+  close: () => Promise<void>;
+}
+
+/**
+ * Starts the deprecated authenticated SSE transport.
+ *
+ * @param options - Port, MCP server factory, and bearer token for the server.
+ * @returns A handle that reports readiness and closes all active sessions.
+ */
 export function createSSEServer(
   { port, createMcpServer, authToken }: SSEServerOptions,
-): { close: () => Promise<void> } {
+): SSEServerHandle {
   const logger = getLogger(["media-server-mcp", "transport", "sse"]);
 
   logger.warn(
@@ -24,8 +36,11 @@ export function createSSEServer(
       "SSE will be removed in a future release.",
   );
 
-  // Store transports by session ID
-  const transports = new Map<string, SSEServerTransport>();
+  // Store each session's transport and server so both are released together.
+  const sessions = new Map<
+    string,
+    { transport: SSEServerTransport; close: () => Promise<void> }
+  >();
 
   const httpServer = createServer(async (req, res) => {
     try {
@@ -62,7 +77,7 @@ export function createSSEServer(
 
       if (pathname === "/sse") {
         // SSE endpoint - establishes event stream connection
-        if (transports.size >= MAX_SESSIONS) {
+        if (sessions.size >= MAX_SESSIONS) {
           res.writeHead(503, { "Content-Type": "application/json" });
           res.end(JSON.stringify({ error: "Too many active sessions" }));
           logger.warn("Session limit reached ({max}), rejecting new session", {
@@ -83,17 +98,57 @@ export function createSSEServer(
         res.setHeader("Connection", "keep-alive");
         res.setHeader("mcp-session-id", sessionId);
 
-        transports.set(sessionId, transport);
-
         // Each legacy SSE session gets its own server instance.
         const server = await createMcpServer();
-        await server.connect(transport);
+        let closeServerPromise: Promise<void> | undefined;
+        const closeServer = () => {
+          closeServerPromise ??= server.close();
+          return closeServerPromise;
+        };
+        const closeSession = async () => {
+          const failures: unknown[] = [];
+          try {
+            await transport.close();
+          } catch (error) {
+            failures.push(error);
+          }
+          try {
+            await closeServer();
+          } catch (error) {
+            failures.push(error);
+          }
+          if (failures.length > 0) {
+            throw new AggregateError(failures, "Failed to close SSE session");
+          }
+        };
 
-        // Handle cleanup when connection closes
+        // Handle cleanup when connection closes.
         transport.onclose = () => {
-          transports.delete(sessionId);
+          sessions.delete(sessionId);
+          closeServer().catch((error) => {
+            logger.error("Error closing MCP server for session {sessionId}", {
+              sessionId,
+              error: error instanceof Error ? error.message : String(error),
+            });
+          });
           logger.info("SSE session closed: {sessionId}", { sessionId });
         };
+        sessions.set(sessionId, { transport, close: closeSession });
+
+        try {
+          await server.connect(transport);
+        } catch (error) {
+          sessions.delete(sessionId);
+          await closeServer().catch((closeError) => {
+            logger.error("Error closing MCP server for session {sessionId}", {
+              sessionId,
+              error: closeError instanceof Error
+                ? closeError.message
+                : String(closeError),
+            });
+          });
+          throw error;
+        }
 
         logger.info("SSE session established: {sessionId}", { sessionId });
       } else if (pathname === "/messages") {
@@ -111,8 +166,8 @@ export function createSSEServer(
           return;
         }
 
-        const transport = transports.get(sessionId);
-        if (!transport) {
+        const session = sessions.get(sessionId);
+        if (!session) {
           res.writeHead(400, { "Content-Type": "application/json" });
           res.end(
             JSON.stringify({ error: "Invalid or expired sessionId" }),
@@ -129,13 +184,13 @@ export function createSSEServer(
           return;
         }
 
-        await transport.handlePostMessage(req, res, body);
+        await session.transport.handlePostMessage(req, res, body);
       } else if (pathname === "/health") {
         // Health check endpoint
         res.writeHead(200, { "Content-Type": "application/json" });
         res.end(JSON.stringify({
           status: "healthy",
-          activeSessions: transports.size,
+          activeSessions: sessions.size,
           timestamp: new Date().toISOString(),
         }));
       } else {
@@ -169,11 +224,22 @@ export function createSSEServer(
     url: `http://localhost:${port}/health`,
   });
 
-  httpServer.listen(port, () => {
-    logger.info("SSE server listening on port {port}", { port });
+  const ready = new Promise<void>((resolve) => {
+    httpServer.listen(port, () => {
+      logger.info("SSE server listening on port {port}", { port });
+      resolve();
+    });
   });
 
   return {
-    close: () => closeTransportServer(transports, httpServer, logger, "SSE"),
+    ready,
+    port: () => {
+      const address = httpServer.address();
+      if (!address || typeof address === "string") {
+        throw new Error("SSE server is not listening");
+      }
+      return address.port;
+    },
+    close: () => closeTransportServer(sessions, httpServer, logger, "SSE"),
   };
 }

--- a/packages/media-server-mcp/src/transports/sse.ts
+++ b/packages/media-server-mcp/src/transports/sse.ts
@@ -1,6 +1,6 @@
 import { createServer } from "node:http";
-import { SSEServerTransport } from "@modelcontextprotocol/sdk/server/sse.js";
-import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { SSEServerTransport } from "@modelcontextprotocol/server-legacy/sse";
+import type { McpServer } from "@modelcontextprotocol/server";
 import { getLogger } from "../logging.ts";
 import { validateBearerToken } from "../auth.ts";
 import { closeTransportServer, readBody, setCorsHeaders } from "./shared.ts";
@@ -10,12 +10,12 @@ const MAX_SESSIONS = 100;
 
 interface SSEServerOptions {
   port: number;
-  server: McpServer;
+  createMcpServer: () => Promise<McpServer>;
   authToken: string;
 }
 
 export function createSSEServer(
-  { port, server, authToken }: SSEServerOptions,
+  { port, createMcpServer, authToken }: SSEServerOptions,
 ): { close: () => Promise<void> } {
   const logger = getLogger(["media-server-mcp", "transport", "sse"]);
 
@@ -85,7 +85,8 @@ export function createSSEServer(
 
         transports.set(sessionId, transport);
 
-        // Connect MCP server to this transport
+        // Each legacy SSE session gets its own server instance.
+        const server = await createMcpServer();
         await server.connect(transport);
 
         // Handle cleanup when connection closes

--- a/packages/media-server-mcp/src/transports/stdio.ts
+++ b/packages/media-server-mcp/src/transports/stdio.ts
@@ -1,33 +1,29 @@
-import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
-import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { type McpServer } from "@modelcontextprotocol/server";
+import { serveStdio } from "@modelcontextprotocol/server/stdio";
 import { getLogger } from "../logging.ts";
 
 interface StdioServerOptions {
-  server: McpServer;
+  createMcpServer: () => Promise<McpServer>;
 }
 
-export async function createStdioServer(
-  { server }: StdioServerOptions,
-): Promise<{ close: () => Promise<void> }> {
+export function createStdioServer(
+  { createMcpServer }: StdioServerOptions,
+): { close: () => Promise<void> } {
   const logger = getLogger(["media-server-mcp", "transport", "stdio"]);
 
-  const transport = new StdioServerTransport();
-  await server.connect(transport);
+  const server = serveStdio(createMcpServer, {
+    onerror: (error) => {
+      logger.error("Stdio server error", { error: error.message });
+    },
+  });
 
   logger.info("Media Server MCP Server running on stdio");
 
   return {
-    close: () => {
+    close: async () => {
       logger.info("Closing stdio server");
-      try {
-        transport.close();
-        logger.info("Stdio server closed");
-      } catch (error) {
-        logger.error("Error closing stdio transport", {
-          error: error instanceof Error ? error.message : String(error),
-        });
-      }
-      return Promise.resolve();
+      await server.close();
+      logger.info("Stdio server closed");
     },
   };
 }

--- a/packages/media-server-mcp/src/transports/streamable-http.ts
+++ b/packages/media-server-mcp/src/transports/streamable-http.ts
@@ -1,76 +1,74 @@
+import { createServer } from "node:http";
+import { createMcpHandler, type McpServer } from "@modelcontextprotocol/server";
 import {
-  createServer,
-  type IncomingMessage,
-  type ServerResponse,
-} from "node:http";
-import { randomUUID } from "node:crypto";
-import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
-import type { Transport } from "@modelcontextprotocol/sdk/shared/transport.js";
-import { isInitializeRequest } from "@modelcontextprotocol/sdk/types.js";
-import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { getLogger } from "../logging.ts";
+  type NodeIncomingMessageLike,
+  type NodeServerResponseLike,
+  toNodeHandler,
+} from "@modelcontextprotocol/node";
 import { validateBearerToken } from "../auth.ts";
-import { closeTransportServer, readBody, setCorsHeaders } from "./shared.ts";
-
-/** Default idle timeout for sessions: 30 minutes. */
-const SESSION_IDLE_TIMEOUT_MS = 30 * 60 * 1000;
-
-/** Maximum number of concurrent sessions to prevent resource exhaustion. */
-const MAX_SESSIONS = 100;
+import { getLogger } from "../logging.ts";
+import { closeTransportServer, setCorsHeaders } from "./shared.ts";
 
 interface StreamableHTTPServerOptions {
   port: number;
   host: string;
-  createMcpServer: () => Promise<McpServer>;
+  createMcpServer: () => McpServer | Promise<McpServer>;
   authToken: string | undefined;
 }
 
-interface SessionEntry {
-  transport: StreamableHTTPServerTransport;
-  lastActivity: number;
+interface StreamableHTTPServerHandle {
+  ready: Promise<void>;
+  port: () => number;
+  close: () => Promise<void>;
 }
 
+/**
+ * Starts a dual-era Streamable HTTP server.
+ *
+ * The MCP SDK creates an isolated server instance for every HTTP request. This
+ * keeps 2026-07-28 requests stateless while preserving the SDK's 2025-era
+ * stateless compatibility path for older clients.
+ */
 export function createStreamableHTTPServer(
   { port, host, createMcpServer, authToken }: StreamableHTTPServerOptions,
-): { close: () => Promise<void> } {
+): StreamableHTTPServerHandle {
   const logger = getLogger([
     "media-server-mcp",
     "transport",
     "streamable-http",
   ]);
-
-  const sessions = new Map<string, SessionEntry>();
+  const mcpHandler = createMcpHandler(createMcpServer);
+  const nodeMcpHandler = toNodeHandler(mcpHandler, {
+    onerror: (error) => {
+      logger.error("MCP handler failed", { error: error.message });
+    },
+  });
 
   const httpServer = createServer(async (req, res) => {
     try {
       setCorsHeaders(
         res,
-        "GET, POST, DELETE, OPTIONS",
-        "Content-Type, Accept, Authorization, Mcp-Session-Id",
-        "Mcp-Session-Id",
+        "POST, OPTIONS",
+        "Content-Type, Accept, Authorization, MCP-Protocol-Version, Mcp-Method, Mcp-Name",
+        "",
       );
 
       if (req.method === "OPTIONS") {
-        res.writeHead(200);
+        res.writeHead(204);
         res.end();
         return;
       }
 
-      const url = new URL(req.url || "", `http://${req.headers.host}`);
-      const pathname = url.pathname;
-
-      // Health check endpoint — no auth required
-      if (pathname === "/health") {
+      const url = new URL(req.url || "/", `http://${req.headers.host}`);
+      if (url.pathname === "/health") {
         res.writeHead(200, { "Content-Type": "application/json" });
         res.end(JSON.stringify({
           status: "healthy",
-          activeSessions: sessions.size,
           timestamp: new Date().toISOString(),
         }));
         return;
       }
 
-      // Validate Bearer token when configured
       if (authToken && !validateBearerToken(req, authToken)) {
         res.writeHead(401, { "Content-Type": "application/json" });
         res.end(JSON.stringify({
@@ -78,7 +76,7 @@ export function createStreamableHTTPServer(
           message: "Valid Bearer token required",
         }));
         logger.warn("Unauthorized access attempt", {
-          pathname,
+          pathname: url.pathname,
           method: req.method,
           ip: req.socket.remoteAddress,
           userAgent: req.headers["user-agent"],
@@ -86,24 +84,19 @@ export function createStreamableHTTPServer(
         return;
       }
 
-      // All MCP traffic goes through /mcp
-      if (pathname !== "/mcp") {
+      if (url.pathname !== "/mcp") {
         res.writeHead(404, { "Content-Type": "application/json" });
         res.end(JSON.stringify({ error: "Not found" }));
         return;
       }
 
-      if (req.method === "POST") {
-        await handlePost(req, res, createMcpServer, sessions, logger);
-        return;
-      }
-
-      // GET and DELETE operate on existing sessions
-      const entry = getSessionEntry(req, res, sessions);
-      if (!entry) return;
-
-      entry.lastActivity = Date.now();
-      await entry.transport.handleRequest(req, res);
+      // `node:http` models optional request fields as `T | undefined`, while
+      // the adapter uses optional properties. The values are passed through
+      // unchanged and satisfy the adapter's runtime contract.
+      await nodeMcpHandler(
+        req as unknown as NodeIncomingMessageLike,
+        res as NodeServerResponseLike,
+      );
     } catch (error) {
       logger.error("Unhandled error in HTTP handler", {
         method: req.method,
@@ -119,22 +112,6 @@ export function createStreamableHTTPServer(
     }
   });
 
-  // Session idle reaper — runs every 60 seconds
-  const reaper = setInterval(() => {
-    const now = Date.now();
-    for (const [sessionId, entry] of sessions) {
-      if (now - entry.lastActivity > SESSION_IDLE_TIMEOUT_MS) {
-        logger.info("Reaping idle session: {sessionId}", { sessionId });
-        try {
-          entry.transport.close();
-        } catch {
-          // already closed
-        }
-        sessions.delete(sessionId);
-      }
-    }
-  }, 60_000);
-
   logger.info("Starting Streamable HTTP server on {host}:{port}", {
     host,
     port,
@@ -148,142 +125,34 @@ export function createStreamableHTTPServer(
   if (authToken) {
     logger.info("Bearer token authentication enabled");
   } else {
-    logger.warn(
-      "No MCP_AUTH_TOKEN set — running without authentication",
-    );
+    logger.warn("No MCP_AUTH_TOKEN set, running without authentication");
   }
 
-  httpServer.listen(port, host, () => {
-    logger.info("Streamable HTTP server listening on {host}:{port}", {
-      host,
-      port,
+  const ready = new Promise<void>((resolve) => {
+    httpServer.listen(port, host, () => {
+      logger.info("Streamable HTTP server listening on {host}:{port}", {
+        host,
+        port,
+      });
+      resolve();
     });
   });
 
   return {
-    close: () => {
-      clearInterval(reaper);
-
-      const entries = Array.from(
-        sessions,
-        ([id, e]) => [id, e.transport] as [string, { close: () => void }],
-      );
-      sessions.clear();
-
-      return closeTransportServer(
-        entries,
+    ready,
+    port: () => {
+      const address = httpServer.address();
+      if (!address || typeof address === "string") {
+        throw new Error("Streamable HTTP server is not listening");
+      }
+      return address.port;
+    },
+    close: () =>
+      closeTransportServer(
+        [["mcp-handler", mcpHandler]],
         httpServer,
         logger,
         "Streamable HTTP",
-      );
-    },
+      ),
   };
-}
-
-/**
- * Look up a session entry by Mcp-Session-Id header.
- * Sends an error response and returns undefined if not found.
- */
-function getSessionEntry(
-  req: IncomingMessage,
-  res: ServerResponse,
-  sessions: Map<string, SessionEntry>,
-): SessionEntry | undefined {
-  const sessionId = req.headers["mcp-session-id"];
-  const sid = Array.isArray(sessionId) ? sessionId[0] : sessionId;
-
-  if (!sid) {
-    res.writeHead(400, { "Content-Type": "application/json" });
-    res.end(
-      JSON.stringify({ error: "Missing Mcp-Session-Id header" }),
-    );
-    return undefined;
-  }
-
-  const entry = sessions.get(sid);
-  if (!entry) {
-    res.writeHead(404, { "Content-Type": "application/json" });
-    res.end(
-      JSON.stringify({ error: "Invalid or expired session" }),
-    );
-    return undefined;
-  }
-
-  return entry;
-}
-
-/**
- * Handle POST requests to /mcp.
- *
- * If the body is an Initialize request, create a new McpServer and
- * session transport. Otherwise, route to the existing session.
- */
-async function handlePost(
-  req: IncomingMessage,
-  res: ServerResponse,
-  createMcpServer: () => Promise<McpServer>,
-  sessions: Map<string, SessionEntry>,
-  logger: ReturnType<typeof getLogger>,
-): Promise<void> {
-  const body = await readBody(req, res);
-  if (body === undefined) {
-    // readBody already sent 413 if body was too large
-    if (!res.headersSent) {
-      res.writeHead(400, { "Content-Type": "application/json" });
-      res.end(JSON.stringify({ error: "Invalid JSON" }));
-    }
-    return;
-  }
-
-  if (isInitializeRequest(body)) {
-    if (sessions.size >= MAX_SESSIONS) {
-      res.writeHead(503, { "Content-Type": "application/json" });
-      res.end(JSON.stringify({ error: "Too many active sessions" }));
-      logger.warn("Session limit reached ({max}), rejecting new session", {
-        max: MAX_SESSIONS,
-      });
-      return;
-    }
-
-    // Create a fresh McpServer for this session so each session
-    // has its own independent server instance with registered tools
-    const mcpServer = await createMcpServer();
-
-    const transport = new StreamableHTTPServerTransport({
-      sessionIdGenerator: () => randomUUID(),
-    });
-
-    transport.onclose = () => {
-      const sid = transport.sessionId;
-      if (sid) {
-        sessions.delete(sid);
-        logger.info("Session closed: {sessionId}", {
-          sessionId: sid,
-        });
-      }
-    };
-
-    // The SDK's StreamableHTTPServerTransport implements Transport,
-    // but type resolution across npm package boundaries in Deno can
-    // produce a structural mismatch. This cast is safe.
-    await mcpServer.connect(transport as unknown as Transport);
-
-    await transport.handleRequest(req, res, body);
-
-    // The transport's sessionId is only assigned during handleRequest
-    // (when the SDK processes the initialize request), so we must read
-    // it *after* handleRequest completes.
-    const sessionId = transport.sessionId;
-    if (sessionId) {
-      sessions.set(sessionId, { transport, lastActivity: Date.now() });
-      logger.info("Session created: {sessionId}", { sessionId });
-    }
-  } else {
-    // Route to existing session
-    const entry = getSessionEntry(req, res, sessions);
-    if (!entry) return;
-
-    entry.lastActivity = Date.now();
-    await entry.transport.handleRequest(req, res, body);
-  }
 }

--- a/packages/media-server-mcp/src/transports/streamable-http.ts
+++ b/packages/media-server-mcp/src/transports/streamable-http.ts
@@ -2,17 +2,19 @@ import { createServer } from "node:http";
 import { createMcpHandler, type McpServer } from "@modelcontextprotocol/server";
 import {
   type NodeIncomingMessageLike,
+  originValidation,
   toNodeHandler,
 } from "@modelcontextprotocol/node";
 import { validateBearerToken } from "../auth.ts";
 import { getLogger } from "../logging.ts";
-import { closeTransportServer, setCorsHeaders } from "./shared.ts";
+import { closeTransportServer, readBody, setCorsHeaders } from "./shared.ts";
 
 interface StreamableHTTPServerOptions {
   port: number;
   host: string;
   createMcpServer: () => McpServer | Promise<McpServer>;
   authToken: string | undefined;
+  allowedOriginHostnames: string[];
 }
 
 interface StreamableHTTPServerHandle {
@@ -27,9 +29,18 @@ interface StreamableHTTPServerHandle {
  * The MCP SDK creates an isolated server instance for every HTTP request. This
  * keeps 2026-07-28 requests stateless while preserving the SDK's 2025-era
  * stateless compatibility path for older clients.
+ *
+ * @param options - Network, authentication, Origin, and MCP factory options.
+ * @returns A handle that reports readiness and awaits handler teardown.
  */
 export function createStreamableHTTPServer(
-  { port, host, createMcpServer, authToken }: StreamableHTTPServerOptions,
+  {
+    port,
+    host,
+    createMcpServer,
+    authToken,
+    allowedOriginHostnames,
+  }: StreamableHTTPServerOptions,
 ): StreamableHTTPServerHandle {
   const logger = getLogger([
     "media-server-mcp",
@@ -37,6 +48,7 @@ export function createStreamableHTTPServer(
     "streamable-http",
   ]);
   const mcpHandler = createMcpHandler(createMcpServer);
+  const validateOrigin = originValidation(allowedOriginHostnames);
   const nodeMcpHandler = toNodeHandler(mcpHandler, {
     onerror: (error) => {
       logger.error("MCP handler failed", { error: error.message });
@@ -51,6 +63,10 @@ export function createStreamableHTTPServer(
         "Content-Type, Accept, Authorization, MCP-Protocol-Version, Mcp-Method, Mcp-Name",
         "",
       );
+
+      if (!validateOrigin(req, res)) {
+        return;
+      }
 
       if (req.method === "OPTIONS") {
         res.writeHead(204);
@@ -89,15 +105,33 @@ export function createStreamableHTTPServer(
         return;
       }
 
+      if (req.method !== "POST") {
+        res.writeHead(405, {
+          "Content-Type": "application/json",
+          "Allow": "POST, OPTIONS",
+        });
+        res.end(JSON.stringify({ error: "Method not allowed" }));
+        return;
+      }
+
+      const body = await readBody(req, res);
+      if (body === undefined) {
+        if (!res.headersSent) {
+          res.writeHead(400, { "Content-Type": "application/json" });
+          res.end(JSON.stringify({ error: "Invalid JSON" }));
+        }
+        return;
+      }
+
       // Normalize node:http's optional request fields to the adapter's
-      // structural request type without changing the request body stream.
+      // structural request type.
       const nodeRequest: NodeIncomingMessageLike = {
-        method: req.method ?? "GET",
+        method: req.method,
         url: req.url ?? "/",
         headers: req.headers,
         [Symbol.asyncIterator]: () => req[Symbol.asyncIterator](),
       };
-      await nodeMcpHandler(nodeRequest, res);
+      await nodeMcpHandler(nodeRequest, res, body);
     } catch (error) {
       logger.error("Unhandled error in HTTP handler", {
         method: req.method,

--- a/packages/media-server-mcp/src/transports/streamable-http.ts
+++ b/packages/media-server-mcp/src/transports/streamable-http.ts
@@ -2,7 +2,6 @@ import { createServer } from "node:http";
 import { createMcpHandler, type McpServer } from "@modelcontextprotocol/server";
 import {
   type NodeIncomingMessageLike,
-  type NodeServerResponseLike,
   toNodeHandler,
 } from "@modelcontextprotocol/node";
 import { validateBearerToken } from "../auth.ts";
@@ -90,13 +89,15 @@ export function createStreamableHTTPServer(
         return;
       }
 
-      // `node:http` models optional request fields as `T | undefined`, while
-      // the adapter uses optional properties. The values are passed through
-      // unchanged and satisfy the adapter's runtime contract.
-      await nodeMcpHandler(
-        req as unknown as NodeIncomingMessageLike,
-        res as NodeServerResponseLike,
-      );
+      // Normalize node:http's optional request fields to the adapter's
+      // structural request type without changing the request body stream.
+      const nodeRequest: NodeIncomingMessageLike = {
+        method: req.method ?? "GET",
+        url: req.url ?? "/",
+        headers: req.headers,
+        [Symbol.asyncIterator]: () => req[Symbol.asyncIterator](),
+      };
+      await nodeMcpHandler(nodeRequest, res);
     } catch (error) {
       logger.error("Unhandled error in HTTP handler", {
         method: req.method,

--- a/packages/media-server-mcp/tests/prompts/prompts_test.ts
+++ b/packages/media-server-mcp/tests/prompts/prompts_test.ts
@@ -1,5 +1,5 @@
 import { assertEquals, assertExists } from "@std/assert";
-import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { McpServer } from "@modelcontextprotocol/server";
 import { createRadarrConfig } from "@wyattjoh/radarr";
 import { createSonarrConfig } from "@wyattjoh/sonarr";
 import { createAddMoviePrompt } from "../../src/prompts/add-movie-prompt.ts";
@@ -44,14 +44,19 @@ Deno.test("createRecommendationsPrompt - registers without errors", () => {
   createRecommendationsPrompt(server);
 });
 
-Deno.test("createLibraryReportPrompt - returns valid messages", () => {
+Deno.test("createLibraryReportPrompt - returns valid messages", async () => {
   const server = makeServer();
   createLibraryReportPrompt(server);
 
   // Access the registered prompt via the server's internal prompt registry
-  // by simulating what the SDK does: call the registered callback
+  // and invoke the handler the SDK uses for prompts/get.
   const registered = (server as unknown as {
-    _registeredPrompts: Record<string, { callback: () => unknown }>;
+    _registeredPrompts: Record<string, {
+      handler: (
+        args: Record<string, never>,
+        context: never,
+      ) => Promise<unknown>;
+    }>;
   })._registeredPrompts;
 
   assertExists(registered, "Expected _registeredPrompts to exist on server");
@@ -59,7 +64,7 @@ Deno.test("createLibraryReportPrompt - returns valid messages", () => {
   const prompt = registered["library-report"];
   assertExists(prompt, "Expected library-report prompt to be registered");
 
-  const result = (prompt.callback as () => unknown)();
+  const result = await prompt.handler({}, {} as never);
   const { messages } = result as {
     messages: Array<{ role: string; content: { type: string; text: string } }>;
   };
@@ -71,12 +76,17 @@ Deno.test("createLibraryReportPrompt - returns valid messages", () => {
   assertEquals(typeof messages[0].content.text, "string");
 });
 
-Deno.test("createRecommendationsPrompt - returns valid messages", () => {
+Deno.test("createRecommendationsPrompt - returns valid messages", async () => {
   const server = makeServer();
   createRecommendationsPrompt(server);
 
   const registered = (server as unknown as {
-    _registeredPrompts: Record<string, { callback: () => unknown }>;
+    _registeredPrompts: Record<string, {
+      handler: (
+        args: Record<string, never>,
+        context: never,
+      ) => Promise<unknown>;
+    }>;
   })._registeredPrompts;
 
   assertExists(registered);
@@ -84,7 +94,7 @@ Deno.test("createRecommendationsPrompt - returns valid messages", () => {
   const prompt = registered["recommendations"];
   assertExists(prompt, "Expected recommendations prompt to be registered");
 
-  const result = (prompt.callback as () => unknown)();
+  const result = await prompt.handler({}, {} as never);
   const { messages } = result as {
     messages: Array<{ role: string; content: { type: string; text: string } }>;
   };

--- a/packages/media-server-mcp/tests/resources/plex-resources_test.ts
+++ b/packages/media-server-mcp/tests/resources/plex-resources_test.ts
@@ -1,5 +1,5 @@
 import { assertEquals } from "@std/assert";
-import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { McpServer } from "@modelcontextprotocol/server";
 import { createPlexResources } from "../../src/resources/plex-resources.ts";
 import { createPlexConfig } from "@wyattjoh/plex";
 

--- a/packages/media-server-mcp/tests/resources/radarr-resources_test.ts
+++ b/packages/media-server-mcp/tests/resources/radarr-resources_test.ts
@@ -1,5 +1,5 @@
 import { assertEquals } from "@std/assert";
-import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { McpServer } from "@modelcontextprotocol/server";
 import { createRadarrResources } from "../../src/resources/radarr-resources.ts";
 import { createRadarrConfig } from "@wyattjoh/radarr";
 

--- a/packages/media-server-mcp/tests/resources/sonarr-resources_test.ts
+++ b/packages/media-server-mcp/tests/resources/sonarr-resources_test.ts
@@ -1,5 +1,5 @@
 import { assertEquals } from "@std/assert";
-import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { McpServer } from "@modelcontextprotocol/server";
 import { createSonarrResources } from "../../src/resources/sonarr-resources.ts";
 import { createSonarrConfig } from "@wyattjoh/sonarr";
 

--- a/packages/media-server-mcp/tests/resources/tmdb-resources_test.ts
+++ b/packages/media-server-mcp/tests/resources/tmdb-resources_test.ts
@@ -1,5 +1,5 @@
 import { assertEquals } from "@std/assert";
-import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { McpServer } from "@modelcontextprotocol/server";
 import { createTMDBResources } from "../../src/resources/tmdb-resources.ts";
 import { createTMDBConfig } from "@wyattjoh/tmdb";
 

--- a/packages/media-server-mcp/tests/sse-transport_test.ts
+++ b/packages/media-server-mcp/tests/sse-transport_test.ts
@@ -312,13 +312,17 @@ function openSSESession(port: number): Promise<Response> {
 }
 
 function withTimeout<T>(promise: Promise<T>): Promise<T> {
-  return Promise.race([
-    promise,
-    new Promise<T>((_resolve, reject) => {
-      setTimeout(
-        () => reject(new Error("Timed out waiting for SSE close")),
-        1000,
-      );
-    }),
-  ]);
+  let timeoutId: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<T>((_resolve, reject) => {
+    timeoutId = setTimeout(
+      () => reject(new Error("Timed out waiting for SSE close")),
+      1000,
+    );
+  });
+
+  return Promise.race([promise, timeout]).finally(() => {
+    if (timeoutId !== undefined) {
+      clearTimeout(timeoutId);
+    }
+  });
 }

--- a/packages/media-server-mcp/tests/sse-transport_test.ts
+++ b/packages/media-server-mcp/tests/sse-transport_test.ts
@@ -1,4 +1,6 @@
 import { assertEquals, assertExists } from "@std/assert";
+import { McpServer } from "@modelcontextprotocol/server";
+import { stub } from "@std/testing/mock";
 
 // Tests for SSE transport functionality
 Deno.test("SSE transport module - can be imported without errors", async () => {
@@ -234,3 +236,89 @@ Deno.test("Environment variable validation - auth token requirement", () => {
     assertEquals(validationFails, shouldFail);
   });
 });
+
+Deno.test("closing an SSE connection closes its MCP server", async () => {
+  const { createSSEServer } = await import("../src/transports/sse.ts");
+  const mcpServer = new McpServer({ name: "test", version: "1.0.0" });
+  const closed = Promise.withResolvers<void>();
+  const closeStub = stub(mcpServer, "close", () => {
+    closed.resolve();
+    return Promise.resolve();
+  });
+  const server = createSSEServer({
+    port: 0,
+    authToken: "test-token",
+    createMcpServer: () => Promise.resolve(mcpServer),
+  });
+
+  try {
+    await server.ready;
+    const response = await openSSESession(server.port());
+    await response.body?.cancel();
+    await withTimeout(closed.promise);
+
+    const health = await fetch(`http://127.0.0.1:${server.port()}/health`);
+    const body = await health.json() as { activeSessions: number };
+    assertEquals(body.activeSessions, 0);
+    assertEquals(closeStub.calls.length, 1);
+  } finally {
+    await server.close();
+    closeStub.restore();
+  }
+});
+
+Deno.test("SSE shutdown closes every session server after a close failure", async () => {
+  const { createSSEServer } = await import("../src/transports/sse.ts");
+  const servers = [
+    new McpServer({ name: "first", version: "1.0.0" }),
+    new McpServer({ name: "second", version: "1.0.0" }),
+  ];
+  const firstClose = stub(
+    servers[0],
+    "close",
+    () => Promise.reject(new Error("expected close failure")),
+  );
+  const secondClose = stub(servers[1], "close", () => Promise.resolve());
+  let nextServer = 0;
+  const server = createSSEServer({
+    port: 0,
+    authToken: "test-token",
+    createMcpServer: () => Promise.resolve(servers[nextServer++]),
+  });
+
+  try {
+    await server.ready;
+    const responses = await Promise.all([
+      openSSESession(server.port()),
+      openSSESession(server.port()),
+    ]);
+
+    await server.close();
+    assertEquals(firstClose.calls.length, 1);
+    assertEquals(secondClose.calls.length, 1);
+    for (const response of responses) {
+      await response.body?.cancel();
+    }
+  } finally {
+    firstClose.restore();
+    secondClose.restore();
+  }
+});
+
+function openSSESession(port: number): Promise<Response> {
+  return fetch(`http://127.0.0.1:${port}/sse`, {
+    headers: { Authorization: "Bearer test-token" },
+  });
+}
+
+function withTimeout<T>(promise: Promise<T>): Promise<T> {
+  return Promise.race([
+    promise,
+    new Promise<T>((_resolve, reject) => {
+      setTimeout(
+        () => reject(new Error("Timed out waiting for SSE close")),
+        1000,
+      );
+    }),
+  ]);
+}

--- a/packages/media-server-mcp/tests/streamable-http-transport_test.ts
+++ b/packages/media-server-mcp/tests/streamable-http-transport_test.ts
@@ -134,6 +134,7 @@ Deno.test("HTTP server rejects oversized and malformed MCP request bodies", asyn
       body: "x".repeat(1024 * 1024 + 1),
     });
     assertEquals(oversized.status, 413);
+    await oversized.text();
 
     const malformed = await fetch(baseUrl, {
       method: "POST",
@@ -141,6 +142,7 @@ Deno.test("HTTP server rejects oversized and malformed MCP request bodies", asyn
       body: "{",
     });
     assertEquals(malformed.status, 400);
+    await malformed.text();
   } finally {
     await server.close();
   }
@@ -159,15 +161,18 @@ Deno.test("HTTP server rejects unexpected origins and permits allowed or absent 
     }, url));
     assertEquals(rejected.status, 403);
     assertEquals(factoryCalls, 0);
+    await rejected.text();
 
     const allowed = await fetch(modernRequest("server/discover", {
       Origin: "http://localhost:5173",
     }, url));
     assertEquals(allowed.status, 200);
+    await allowed.text();
 
     const absent = await fetch(modernRequest("server/discover", {}, url));
     assertEquals(absent.status, 200);
     assertEquals(factoryCalls, 2);
+    await absent.text();
   } finally {
     await server.close();
   }
@@ -184,6 +189,7 @@ Deno.test("HTTP server rejects unsupported MCP methods without reading a body", 
         ...(method === "GET" ? {} : { body: "x".repeat(1024 * 1024 + 1) }),
       });
       assertEquals(response.status, 405);
+      await response.text();
     }
   } finally {
     await server.close();

--- a/packages/media-server-mcp/tests/streamable-http-transport_test.ts
+++ b/packages/media-server-mcp/tests/streamable-http-transport_test.ts
@@ -1,13 +1,9 @@
 import { assertEquals, assertExists } from "@std/assert";
+import { createServer as createNodeServer } from "node:http";
 import { createMcpHandler, McpServer } from "@modelcontextprotocol/server";
+import { getLogger } from "../src/logging.ts";
+import { closeTransportServer } from "../src/transports/shared.ts";
 import { createStreamableHTTPServer } from "../src/transports/streamable-http.ts";
-
-Deno.test("Streamable HTTP transport module can be imported", async () => {
-  const { createStreamableHTTPServer } = await import(
-    "../src/transports/streamable-http.ts"
-  );
-  assertEquals(typeof createStreamableHTTPServer, "function");
-});
 
 Deno.test("Shared transport module can be imported", async () => {
   const mod = await import("../src/transports/shared.ts");
@@ -95,6 +91,7 @@ Deno.test("HTTP server routes modern requests through the Node adapter", async (
       );
     },
     authToken: undefined,
+    allowedOriginHostnames: ["localhost", "127.0.0.1", "[::1]"],
   });
 
   await server.ready;
@@ -115,11 +112,114 @@ Deno.test("HTTP server routes modern requests through the Node adapter", async (
       response.headers.get("access-control-allow-methods"),
       "POST, OPTIONS",
     );
+    assertEquals(
+      response.headers.get("access-control-expose-headers"),
+      null,
+    );
     assertEquals(body.result.resultType, "complete");
     assertEquals(factoryCalls, 1);
   } finally {
     await server.close();
   }
+});
+
+Deno.test("HTTP server rejects oversized and malformed MCP request bodies", async () => {
+  const server = createTestServer();
+  await server.ready;
+  try {
+    const baseUrl = `http://127.0.0.1:${server.port()}/mcp`;
+    const oversized = await fetch(baseUrl, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: "x".repeat(1024 * 1024 + 1),
+    });
+    assertEquals(oversized.status, 413);
+
+    const malformed = await fetch(baseUrl, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: "{",
+    });
+    assertEquals(malformed.status, 400);
+  } finally {
+    await server.close();
+  }
+});
+
+Deno.test("HTTP server rejects unexpected origins and permits allowed or absent origins", async () => {
+  let factoryCalls = 0;
+  const server = createTestServer(() => {
+    factoryCalls += 1;
+  });
+  await server.ready;
+  try {
+    const url = `http://127.0.0.1:${server.port()}/mcp`;
+    const rejected = await fetch(modernRequest("server/discover", {
+      Origin: "https://untrusted.example",
+    }, url));
+    assertEquals(rejected.status, 403);
+    assertEquals(factoryCalls, 0);
+
+    const allowed = await fetch(modernRequest("server/discover", {
+      Origin: "http://localhost:5173",
+    }, url));
+    assertEquals(allowed.status, 200);
+
+    const absent = await fetch(modernRequest("server/discover", {}, url));
+    assertEquals(absent.status, 200);
+    assertEquals(factoryCalls, 2);
+  } finally {
+    await server.close();
+  }
+});
+
+Deno.test("HTTP server rejects unsupported MCP methods without reading a body", async () => {
+  const server = createTestServer();
+  await server.ready;
+  try {
+    const url = `http://127.0.0.1:${server.port()}/mcp`;
+    for (const method of ["GET", "DELETE", "PUT"]) {
+      const response = await fetch(url, {
+        method,
+        ...(method === "GET" ? {} : { body: "x".repeat(1024 * 1024 + 1) }),
+      });
+      assertEquals(response.status, 405);
+    }
+  } finally {
+    await server.close();
+  }
+});
+
+Deno.test("transport shutdown awaits closeables and continues after rejection", async () => {
+  const httpServer = createNodeServer();
+  await new Promise<void>((resolve) => httpServer.listen(0, resolve));
+
+  const teardown = Promise.withResolvers<void>();
+  let finalCloseCalled = false;
+  let shutdownSettled = false;
+  const shutdown = closeTransportServer(
+    [
+      ["async", { close: () => teardown.promise }],
+      ["rejecting", { close: () => Promise.reject(new Error("boom")) }],
+      ["final", {
+        close: () => {
+          finalCloseCalled = true;
+        },
+      }],
+    ],
+    httpServer,
+    getLogger(["media-server-mcp", "test"]),
+    "test",
+  ).then(() => {
+    shutdownSettled = true;
+  });
+
+  await Promise.resolve();
+  assertEquals(shutdownSettled, false);
+  teardown.resolve();
+  await shutdown;
+  assertEquals(finalCloseCalled, true);
+  assertEquals(shutdownSettled, true);
 });
 
 Deno.test("MCP handler rejects a mismatched modern method header", async () => {
@@ -136,6 +236,22 @@ Deno.test("MCP handler rejects a mismatched modern method header", async () => {
 
   await handler.close();
 });
+
+function createTestServer(onCreate: () => void = () => {}) {
+  return createStreamableHTTPServer({
+    port: 0,
+    host: "127.0.0.1",
+    createMcpServer: () => {
+      onCreate();
+      return new McpServer(
+        { name: "test-server", version: "1.0.0" },
+        { capabilities: { tools: {} } },
+      );
+    },
+    authToken: undefined,
+    allowedOriginHostnames: ["localhost", "127.0.0.1", "[::1]"],
+  });
+}
 
 function modernRequest(
   method: string,

--- a/packages/media-server-mcp/tests/streamable-http-transport_test.ts
+++ b/packages/media-server-mcp/tests/streamable-http-transport_test.ts
@@ -1,15 +1,169 @@
-import { assertEquals } from "@std/assert";
+import { assertEquals, assertExists } from "@std/assert";
+import { createMcpHandler, McpServer } from "@modelcontextprotocol/server";
+import { createStreamableHTTPServer } from "../src/transports/streamable-http.ts";
 
-Deno.test("Streamable HTTP transport module - can be imported without errors", async () => {
+Deno.test("Streamable HTTP transport module can be imported", async () => {
   const { createStreamableHTTPServer } = await import(
     "../src/transports/streamable-http.ts"
   );
   assertEquals(typeof createStreamableHTTPServer, "function");
 });
 
-Deno.test("Shared transport module - can be imported without errors", async () => {
+Deno.test("Shared transport module can be imported", async () => {
   const mod = await import("../src/transports/shared.ts");
   assertEquals(typeof mod.readBody, "function");
   assertEquals(typeof mod.setCorsHeaders, "function");
   assertEquals(typeof mod.closeTransportServer, "function");
 });
+
+Deno.test("MCP handler serves a complete 2026-07-28 discovery result", async () => {
+  const handler = createMcpHandler(
+    () =>
+      new McpServer(
+        { name: "test-server", version: "1.0.0" },
+        { capabilities: { tools: {} } },
+      ),
+  );
+
+  const response = await handler.fetch(modernRequest("server/discover"));
+  const body = await response.json() as {
+    result: {
+      resultType: string;
+      supportedVersions: string[];
+      ttlMs: number;
+      cacheScope: string;
+      _meta: Record<string, unknown>;
+    };
+  };
+
+  assertEquals(response.status, 200);
+  assertEquals(body.result.resultType, "complete");
+  assertEquals(body.result.supportedVersions.includes("2026-07-28"), true);
+  assertEquals(typeof body.result.ttlMs, "number");
+  assertEquals(body.result.cacheScope, "private");
+  assertExists(body.result._meta["io.modelcontextprotocol/serverInfo"]);
+
+  await handler.close();
+});
+
+Deno.test("MCP handler preserves the 2025-era compatibility path", async () => {
+  const handler = createMcpHandler(
+    () => new McpServer({ name: "test-server", version: "1.0.0" }),
+  );
+  const response = await handler.fetch(
+    new Request("http://test.local/mcp", {
+      method: "POST",
+      headers: {
+        Accept: "application/json, text/event-stream",
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: "legacy-request-1",
+        method: "initialize",
+        params: {
+          protocolVersion: "2025-11-25",
+          capabilities: {},
+          clientInfo: { name: "legacy-client", version: "1.0.0" },
+        },
+      }),
+    }),
+  );
+  const sseMessage = await response.text();
+  const data = sseMessage.split("\n").find((line) => line.startsWith("data: "));
+  assertExists(data);
+  const body = JSON.parse(data.slice("data: ".length)) as {
+    result: { protocolVersion: string };
+  };
+
+  assertEquals(response.status, 200);
+  assertEquals(body.result.protocolVersion, "2025-11-25");
+
+  await handler.close();
+});
+
+Deno.test("HTTP server routes modern requests through the Node adapter", async () => {
+  let factoryCalls = 0;
+  const server = createStreamableHTTPServer({
+    port: 0,
+    host: "127.0.0.1",
+    createMcpServer: () => {
+      factoryCalls += 1;
+      return new McpServer(
+        { name: "test-server", version: "1.0.0" },
+        { capabilities: { tools: {} } },
+      );
+    },
+    authToken: undefined,
+  });
+
+  await server.ready;
+  try {
+    const response = await fetch(
+      modernRequest(
+        "server/discover",
+        {},
+        `http://127.0.0.1:${server.port()}/mcp`,
+      ),
+    );
+    const body = await response.json() as {
+      result: { resultType: string };
+    };
+
+    assertEquals(response.status, 200);
+    assertEquals(
+      response.headers.get("access-control-allow-methods"),
+      "POST, OPTIONS",
+    );
+    assertEquals(body.result.resultType, "complete");
+    assertEquals(factoryCalls, 1);
+  } finally {
+    await server.close();
+  }
+});
+
+Deno.test("MCP handler rejects a mismatched modern method header", async () => {
+  const handler = createMcpHandler(
+    () => new McpServer({ name: "test-server", version: "1.0.0" }),
+  );
+  const response = await handler.fetch(
+    modernRequest("server/discover", { "Mcp-Method": "tools/list" }),
+  );
+  const body = await response.json() as { error: { code: number } };
+
+  assertEquals(response.status, 400);
+  assertEquals(body.error.code, -32020);
+
+  await handler.close();
+});
+
+function modernRequest(
+  method: string,
+  headers: HeadersInit = {},
+  url = "http://test.local/mcp",
+): Request {
+  return new Request(url, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "MCP-Protocol-Version": "2026-07-28",
+      "Mcp-Method": method,
+      ...headers,
+    },
+    body: JSON.stringify({
+      jsonrpc: "2.0",
+      id: "request-1",
+      method: "server/discover",
+      params: {
+        _meta: {
+          "io.modelcontextprotocol/protocolVersion": "2026-07-28",
+          "io.modelcontextprotocol/clientCapabilities": {},
+          "io.modelcontextprotocol/clientInfo": {
+            name: "test-client",
+            version: "1.0.0",
+          },
+        },
+      },
+    }),
+  });
+}

--- a/packages/media-server-mcp/tests/tools/history-event-type-contract_test.ts
+++ b/packages/media-server-mcp/tests/tools/history-event-type-contract_test.ts
@@ -52,10 +52,15 @@ Deno.test(
       {
         name: "radarr_get_history",
         eventTypes: [
+          // Upstream enum source:
+          // https://github.com/Radarr/Radarr/blob/develop/src/NzbDrone.Core/History/History.cs
+          // Unknown=0, Grabbed=1, deprecated SeriesFolderImported=2,
+          // DownloadFolderImported=3, DownloadFailed=4, deprecated inherited
+          // EpisodeFileDeleted=5, MovieFileDeleted=6.
           ["grabbed", 1],
           ["downloadFolderImported", 3],
           ["downloadFailed", 4],
-          ["movieFileDeleted", 5],
+          ["movieFileDeleted", 6],
         ],
         register: (server: McpServer) =>
           createRadarrTools(

--- a/packages/media-server-mcp/tests/tools/history-event-type-contract_test.ts
+++ b/packages/media-server-mcp/tests/tools/history-event-type-contract_test.ts
@@ -1,0 +1,140 @@
+import { assertEquals } from "@std/assert";
+import { stub } from "@std/testing/mock";
+import { Client } from "@modelcontextprotocol/client";
+import { InMemoryTransport, McpServer } from "@modelcontextprotocol/server";
+import { createRadarrConfig } from "@wyattjoh/radarr";
+import { createSonarrConfig } from "@wyattjoh/sonarr";
+import { createRadarrTools } from "../../src/tools/radarr-tools.ts";
+import { createSonarrTools } from "../../src/tools/sonarr-tools.ts";
+
+async function createConnectedClient(
+  server: McpServer,
+): Promise<{ client: Client; cleanup: () => Promise<void> }> {
+  const [clientTransport, serverTransport] = InMemoryTransport
+    .createLinkedPair();
+  await server.connect(serverTransport);
+  const client = new Client({ name: "test-client", version: "1.0.0" });
+  await client.connect(clientTransport);
+  return {
+    client,
+    cleanup: async () => {
+      await client.close();
+    },
+  };
+}
+
+Deno.test(
+  "paginated history tools translate documented event names to API identifiers",
+  async () => {
+    const requestedUrls: URL[] = [];
+    const fetchStub = stub(
+      globalThis,
+      "fetch",
+      (input: RequestInfo | URL) => {
+        requestedUrls.push(
+          new URL(input instanceof Request ? input.url : input.toString()),
+        );
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({
+              page: 1,
+              pageSize: 20,
+              totalRecords: 0,
+              records: [],
+            }),
+            { status: 200, headers: { "Content-Type": "application/json" } },
+          ),
+        );
+      },
+    );
+
+    const tools = [
+      {
+        name: "radarr_get_history",
+        eventTypes: [
+          ["grabbed", 1],
+          ["downloadFolderImported", 3],
+          ["downloadFailed", 4],
+          ["movieFileDeleted", 5],
+        ],
+        register: (server: McpServer) =>
+          createRadarrTools(
+            server,
+            createRadarrConfig("http://localhost:7878", "test-api-key"),
+            () => true,
+          ),
+      },
+      {
+        name: "sonarr_get_history",
+        eventTypes: [
+          ["grabbed", 1],
+          ["downloadFolderImported", 3],
+          ["downloadFailed", 4],
+          ["episodeFileDeleted", 5],
+        ],
+        register: (server: McpServer) =>
+          createSonarrTools(
+            server,
+            createSonarrConfig("http://localhost:8989", "test-api-key"),
+            () => true,
+          ),
+      },
+    ] as const;
+
+    try {
+      for (const tool of tools) {
+        const server = new McpServer({ name: "test", version: "1.0.0" });
+        tool.register(server);
+        const { client, cleanup } = await createConnectedClient(server);
+
+        try {
+          for (const [eventType, eventTypeId] of tool.eventTypes) {
+            const result = await client.callTool({
+              name: tool.name,
+              arguments: { eventType },
+            });
+
+            assertEquals(result.isError, undefined);
+            assertEquals(
+              requestedUrls.at(-1)?.searchParams.get("eventType"),
+              eventTypeId.toString(),
+              `${tool.name} should send ${eventType} as ${eventTypeId}`,
+            );
+          }
+
+          const unfilteredResult = await client.callTool({
+            name: tool.name,
+            arguments: {},
+          });
+          assertEquals(unfilteredResult.isError, undefined);
+          assertEquals(
+            requestedUrls.at(-1)?.searchParams.has("eventType"),
+            false,
+            `${tool.name} should omit eventType when no filter is requested`,
+          );
+
+          const requestCount = requestedUrls.length;
+          const invalidResult = await client.callTool({
+            name: tool.name,
+            arguments: { eventType: "unsupported" },
+          });
+          assertEquals(invalidResult.isError, true);
+          assertEquals(
+            JSON.stringify(invalidResult.content).includes("grabbed"),
+            true,
+            `${tool.name} should explain which event types are supported`,
+          );
+          assertEquals(
+            requestedUrls.length,
+            requestCount,
+            `${tool.name} should reject unsupported event types before the API request`,
+          );
+        } finally {
+          await cleanup();
+        }
+      }
+    } finally {
+      fetchStub.restore();
+    }
+  },
+);

--- a/packages/media-server-mcp/tests/tools/plex-tools-execution_test.ts
+++ b/packages/media-server-mcp/tests/tools/plex-tools-execution_test.ts
@@ -1,8 +1,7 @@
 import { assertEquals, assertExists } from "@std/assert";
 import { stub } from "@std/testing/mock";
-import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
-import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport, McpServer } from "@modelcontextprotocol/server";
+import { Client } from "@modelcontextprotocol/client";
 import { createPlexConfig } from "@wyattjoh/plex";
 import { createPlexTools } from "../../src/tools/plex-tools.ts";
 

--- a/packages/media-server-mcp/tests/tools/radarr-tools-execution_test.ts
+++ b/packages/media-server-mcp/tests/tools/radarr-tools-execution_test.ts
@@ -1,8 +1,7 @@
 import { assertEquals, assertExists } from "@std/assert";
 import { stub } from "@std/testing/mock";
-import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
-import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport, McpServer } from "@modelcontextprotocol/server";
+import { Client } from "@modelcontextprotocol/client";
 import { createRadarrConfig } from "@wyattjoh/radarr";
 import { createRadarrTools } from "../../src/tools/radarr-tools.ts";
 

--- a/packages/media-server-mcp/tests/tools/radarr-tools_test.ts
+++ b/packages/media-server-mcp/tests/tools/radarr-tools_test.ts
@@ -1,5 +1,5 @@
 import { assertEquals } from "@std/assert";
-import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { McpServer } from "@modelcontextprotocol/server";
 import { createRadarrTools } from "../../src/tools/radarr-tools.ts";
 import { createRadarrConfig } from "@wyattjoh/radarr";
 

--- a/packages/media-server-mcp/tests/tools/sonarr-tools-execution_test.ts
+++ b/packages/media-server-mcp/tests/tools/sonarr-tools-execution_test.ts
@@ -290,3 +290,60 @@ Deno.test(
     }
   },
 );
+
+Deno.test(
+  "sonarr_get_queue - returns paginated structuredContent",
+  async () => {
+    const fetchStub = stub(
+      globalThis,
+      "fetch",
+      () =>
+        Promise.resolve(
+          new Response(
+            JSON.stringify({
+              page: 1,
+              pageSize: 20,
+              totalRecords: 1,
+              records: [{ id: 1, title: "Downloading episode" }],
+            }),
+            { status: 200, headers: { "Content-Type": "application/json" } },
+          ),
+        ),
+    );
+
+    try {
+      const server = new McpServer({ name: "test", version: "1.0.0" });
+      const config = createSonarrConfig(
+        "http://localhost:8989",
+        "test-api-key",
+      );
+      createSonarrTools(server, config, () => true);
+
+      const { client, cleanup } = await createConnectedClient(server);
+
+      try {
+        const result = await client.callTool({
+          name: "sonarr_get_queue",
+          arguments: { limit: 20, skip: 0 },
+        });
+
+        assertExists(result.structuredContent);
+        assertEquals(result.isError, undefined);
+
+        const structured = result.structuredContent as Record<string, unknown>;
+        assertEquals(structured.total, 1);
+        assertEquals(structured.returned, 1);
+        assertEquals(structured.skip, 0);
+        assertEquals(structured.limit, 20);
+        assertEquals(structured.data, [{
+          id: 1,
+          title: "Downloading episode",
+        }]);
+      } finally {
+        await cleanup();
+      }
+    } finally {
+      fetchStub.restore();
+    }
+  },
+);

--- a/packages/media-server-mcp/tests/tools/sonarr-tools-execution_test.ts
+++ b/packages/media-server-mcp/tests/tools/sonarr-tools-execution_test.ts
@@ -1,8 +1,7 @@
 import { assertEquals, assertExists } from "@std/assert";
 import { stub } from "@std/testing/mock";
-import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
-import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport, McpServer } from "@modelcontextprotocol/server";
+import { Client } from "@modelcontextprotocol/client";
 import { createSonarrConfig } from "@wyattjoh/sonarr";
 import { createSonarrTools } from "../../src/tools/sonarr-tools.ts";
 

--- a/packages/media-server-mcp/tests/tools/sonarr-tools-execution_test.ts
+++ b/packages/media-server-mcp/tests/tools/sonarr-tools-execution_test.ts
@@ -178,6 +178,62 @@ Deno.test(
 );
 
 Deno.test(
+  "sonarr_get_queue - returns queue records with pagination metadata",
+  async () => {
+    const fetchStub = stub(
+      globalThis,
+      "fetch",
+      () =>
+        Promise.resolve(
+          new Response(
+            JSON.stringify({
+              page: 2,
+              pageSize: 20,
+              sortKey: "timeleft",
+              sortDirection: "ascending",
+              totalRecords: 21,
+              records: [{ id: 1, seriesId: 2, episodeId: 3 }],
+            }),
+            { status: 200, headers: { "Content-Type": "application/json" } },
+          ),
+        ),
+    );
+
+    try {
+      const server = new McpServer({ name: "test", version: "1.0.0" });
+      const config = createSonarrConfig(
+        "http://localhost:8989",
+        "test-api-key",
+      );
+      createSonarrTools(server, config, () => true);
+
+      const { client, cleanup } = await createConnectedClient(server);
+
+      try {
+        const result = await client.callTool({
+          name: "sonarr_get_queue",
+          arguments: { limit: 20, skip: 20 },
+        });
+
+        assertExists(result.structuredContent);
+        assertEquals(result.isError, undefined);
+
+        const structured = result.structuredContent as Record<string, unknown>;
+        assertEquals(structured.total, 21);
+        assertEquals(structured.returned, 1);
+        assertEquals(structured.skip, 20);
+        assertEquals(structured.limit, 20);
+        assertEquals(structured.data, [{ id: 1, seriesId: 2, episodeId: 3 }]);
+      } finally {
+        await cleanup();
+      }
+    } finally {
+      fetchStub.restore();
+    }
+  },
+);
+
+Deno.test(
   "sonarr_get_series - happy path returns structuredContent with series list",
   async () => {
     const mockSeries = [

--- a/packages/media-server-mcp/tests/tools/sonarr-tools_test.ts
+++ b/packages/media-server-mcp/tests/tools/sonarr-tools_test.ts
@@ -1,5 +1,5 @@
 import { assertEquals } from "@std/assert";
-import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { McpServer } from "@modelcontextprotocol/server";
 import { createSonarrTools } from "../../src/tools/sonarr-tools.ts";
 import { createSonarrConfig } from "@wyattjoh/sonarr";
 

--- a/packages/media-server-mcp/tests/tools/tmdb-tools-execution_test.ts
+++ b/packages/media-server-mcp/tests/tools/tmdb-tools-execution_test.ts
@@ -1,8 +1,7 @@
 import { assertEquals, assertExists } from "@std/assert";
 import { stub } from "@std/testing/mock";
-import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
-import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport, McpServer } from "@modelcontextprotocol/server";
+import { Client } from "@modelcontextprotocol/client";
 import { createTMDBConfig } from "@wyattjoh/tmdb";
 import { createTMDBTools } from "../../src/tools/tmdb-tools.ts";
 

--- a/packages/media-server-mcp/tests/tools/tmdb-tools_test.ts
+++ b/packages/media-server-mcp/tests/tools/tmdb-tools_test.ts
@@ -1,5 +1,5 @@
 import { assertEquals } from "@std/assert";
-import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { McpServer } from "@modelcontextprotocol/server";
 import { createTMDBTools } from "../../src/tools/tmdb-tools.ts";
 import { createTMDBConfig } from "@wyattjoh/tmdb";
 

--- a/packages/radarr/src/client.ts
+++ b/packages/radarr/src/client.ts
@@ -508,7 +508,7 @@ export function getHistory(
   pageSize = 20,
   sortKey = "date",
   sortDirection: "ascending" | "descending" = "descending",
-  eventType?: string,
+  eventType?: number,
   includeMovie = false,
 ): Promise<RadarrPaginatedApiResponse<RadarrHistoryRecord>> {
   const params = new URLSearchParams({
@@ -517,7 +517,9 @@ export function getHistory(
     sortKey,
     sortDirection,
   });
-  if (eventType) params.append("eventType", eventType);
+  if (eventType !== undefined) {
+    params.append("eventType", eventType.toString());
+  }
   if (includeMovie) params.append("includeMovie", "true");
 
   return makeRequest<RadarrPaginatedApiResponse<RadarrHistoryRecord>>(

--- a/packages/sonarr/src/client.ts
+++ b/packages/sonarr/src/client.ts
@@ -394,12 +394,19 @@ export async function getCalendar(
   };
 }
 
-// Get queue
-export async function getQueue(
+/**
+ * Fetches one page of the Sonarr download queue with its pagination metadata.
+ *
+ * @param config Sonarr connection configuration.
+ * @param limit Maximum records to request from Sonarr.
+ * @param skip Number of records to skip before the requested page.
+ * @returns The queue records and Sonarr's pagination metadata.
+ */
+export function getQueuePage(
   config: SonarrConfig,
   limit?: number,
   skip?: number,
-): Promise<SonarrQueueItem[]> {
+): Promise<SonarrQueueResponse> {
   const params = new URLSearchParams();
   if (limit !== undefined) params.append("pageSize", limit.toString());
   if (skip !== undefined) {
@@ -409,7 +416,23 @@ export async function getQueue(
   const queryString = params.toString();
   const endpoint = `/queue${queryString ? `?${queryString}` : ""}`;
 
-  const response = await makeRequest<SonarrQueueResponse>(config, endpoint);
+  return makeRequest<SonarrQueueResponse>(config, endpoint);
+}
+
+/**
+ * Fetches the records from one page of the Sonarr download queue.
+ *
+ * @param config Sonarr connection configuration.
+ * @param limit Maximum records to request from Sonarr.
+ * @param skip Number of records to skip before the requested page.
+ * @returns The queue records without pagination metadata.
+ */
+export async function getQueue(
+  config: SonarrConfig,
+  limit?: number,
+  skip?: number,
+): Promise<SonarrQueueItem[]> {
+  const response = await getQueuePage(config, limit, skip);
   return response.records;
 }
 

--- a/packages/sonarr/src/client.ts
+++ b/packages/sonarr/src/client.ts
@@ -619,7 +619,7 @@ export function getHistory(
   pageSize = 20,
   sortKey = "date",
   sortDirection: "ascending" | "descending" = "descending",
-  eventType?: string,
+  eventType?: number,
   includeSeries = false,
   includeEpisode = false,
 ): Promise<SonarrPaginatedApiResponse<SonarrHistoryRecord>> {
@@ -629,7 +629,9 @@ export function getHistory(
     sortKey,
     sortDirection,
   });
-  if (eventType) params.append("eventType", eventType);
+  if (eventType !== undefined) {
+    params.append("eventType", eventType.toString());
+  }
   if (includeSeries) params.append("includeSeries", "true");
   if (includeEpisode) params.append("includeEpisode", "true");
 

--- a/packages/sonarr/tests/client_test.ts
+++ b/packages/sonarr/tests/client_test.ts
@@ -2,6 +2,7 @@ import { assertEquals } from "@std/assert";
 import {
   createSonarrConfig,
   getHistory,
+  getQueuePage,
   getReleases,
   getWantedMissing,
   testConnection,
@@ -56,6 +57,35 @@ Deno.test("getWantedMissing - returns paginated missing episodes", async () => {
     assertEquals(result.totalRecords, 1);
     assertEquals(result.records.length, 1);
     assertEquals(result.records[0].hasFile, false);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+Deno.test("getQueuePage - preserves queue pagination metadata", async () => {
+  const config = createSonarrConfig("http://localhost:8989", "test-key");
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = () => {
+    return Promise.resolve(
+      new Response(
+        JSON.stringify({
+          page: 2,
+          pageSize: 20,
+          sortKey: "timeleft",
+          sortDirection: "ascending",
+          totalRecords: 21,
+          records: [{ id: 1, seriesId: 2, episodeId: 3 }],
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      ),
+    );
+  };
+
+  try {
+    const result = await getQueuePage(config, 20, 20);
+    assertEquals(result.totalRecords, 21);
+    assertEquals(result.records.length, 1);
+    assertEquals(result.records[0].id, 1);
   } finally {
     globalThis.fetch = originalFetch;
   }


### PR DESCRIPTION
## Summary

- Migrate MCP dependencies and server integrations to the v2 package structure.
- Adopt stateless Streamable HTTP for MCP 2026-07-28 with 2025-era compatibility.
- Retain deprecated legacy SSE support and update stdio transport negotiation.
- Add browser Origin validation via `MCP_ALLOWED_ORIGINS`.
- Align structured tool responses with schemas.
- Map Radarr and Sonarr history event names to numeric API identifiers.
- Fix Sonarr queue response output and improve transport shutdown handling.
- Update documentation, CI permissions, and dependency lockfile.

## Related Issues

No related issues specified.

## Test Plan

Added and updated tests covering stateless HTTP discovery and compatibility, Origin validation, malformed and oversized requests, transport shutdown, SSE cleanup, history event mappings, structured tool responses, prompts, resources, and tool execution.

## Checklist

- [ ] `deno check` passes
- [ ] `deno fmt` passes
- [ ] `deno lint` passes
- [ ] `deno test --allow-net --allow-env` passes
- [x] README/CLAUDE.md updated (if tools or resources changed)