### PR TITLE
feat(plex): add global watch history

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -396,6 +396,7 @@ Code Mode suppresses native tool advertisement without changing service resource
 - `plex_search` - Search across all Plex libraries for movies, TV shows, and other content with optional type filters
 - `plex_get_metadata` - Get detailed metadata for a specific movie, TV show, or other media item
 - `plex_get_playback_history` - Get playback history for a specific playable media item, such as a movie or episode, by rating key (up to 1,000 entries per request)
+- `plex_get_watch_history` - Get recent playback history across all playable media, with account and timestamp filters (up to 1,000 entries per request)
 
 #### Collection Management
 

--- a/README.md
+++ b/README.md
@@ -648,6 +648,7 @@ This helps verify your configuration is working as expected.
 - `plex_search` - Search across all Plex libraries for movies, TV shows, and other content with optional type filters
 - `plex_get_metadata` - Get detailed metadata for a specific movie, TV show, or other media item
 - `plex_get_playback_history` - Get playback history for a specific playable media item, such as a movie or episode, by rating key (up to 1,000 entries per request)
+- `plex_get_watch_history` - Get recent playback history across all playable media, with account and timestamp filters (up to 1,000 entries per request)
 
 #### Collection Management
 

--- a/packages/media-server-mcp/src/tools/codemode-executor.ts
+++ b/packages/media-server-mcp/src/tools/codemode-executor.ts
@@ -6,7 +6,7 @@ import { getLogger } from "../logging.ts";
  * Increment this whenever search, describe, execute, policy, or fixed-limit
  * compatibility changes so deployed clients can detect contract drift.
  */
-export const CODEMODE_CONTRACT_REVISION = 2;
+export const CODEMODE_CONTRACT_REVISION = 3;
 
 /**
  * Fixed server-owned resource limits for Code Mode executions.

--- a/packages/media-server-mcp/src/tools/codemode-tools.ts
+++ b/packages/media-server-mcp/src/tools/codemode-tools.ts
@@ -147,6 +147,7 @@ const FACADE_PATHS: Readonly<Record<string, string>> = {
   plex_refresh_library: "tools.plex.refreshLibrary",
   plex_get_library_items: "tools.plex.getLibraryItems",
   plex_get_playback_history: "tools.plex.getPlaybackHistory",
+  plex_get_watch_history: "tools.plex.getWatchHistory",
   plex_get_collections: "tools.plex.getCollections",
   plex_get_collection_items: "tools.plex.getCollectionItems",
   plex_create_collection: "tools.plex.createCollection",
@@ -226,6 +227,7 @@ const EXECUTABLE_READ_ONLY_TOOLS = [
   "plex_get_metadata",
   "plex_get_library_items",
   "plex_get_playback_history",
+  "plex_get_watch_history",
   "plex_get_collections",
   "plex_get_collection_items",
 ] as const;

--- a/packages/media-server-mcp/src/tools/plex-tools.ts
+++ b/packages/media-server-mcp/src/tools/plex-tools.ts
@@ -15,6 +15,47 @@ const SLIM_OMIT_KEYS = new Set([
 const slimReplacer = (key: string, value: unknown) =>
   SLIM_OMIT_KEYS.has(key) ? undefined : value;
 
+function compactLibraryItems(
+  result: Awaited<ReturnType<typeof plexClient.getLibraryItems>>,
+): Record<string, unknown> {
+  const container = result.MediaContainer;
+  return {
+    MediaContainer: {
+      size: container.size,
+      ...(container.totalSize !== undefined && {
+        totalSize: container.totalSize,
+      }),
+      ...(container.offset !== undefined && { offset: container.offset }),
+      identifier: container.identifier,
+      librarySectionID: container.librarySectionID,
+      librarySectionTitle: container.librarySectionTitle,
+      librarySectionUUID: container.librarySectionUUID,
+      ...(container.Metadata !== undefined && {
+        Metadata: container.Metadata.map((item) => ({
+          ratingKey: item.ratingKey,
+          type: item.type,
+          title: item.title,
+          year: item.year,
+          ...(item.viewCount !== undefined && { viewCount: item.viewCount }),
+          ...(item.lastViewedAt !== undefined && {
+            lastViewedAt: item.lastViewedAt,
+          }),
+          ...(item.grandparentTitle !== undefined && {
+            grandparentTitle: item.grandparentTitle,
+          }),
+          ...(item.parentTitle !== undefined && {
+            parentTitle: item.parentTitle,
+          }),
+          ...(item.parentIndex !== undefined && {
+            parentIndex: item.parentIndex,
+          }),
+          ...(item.index !== undefined && { index: item.index }),
+        })),
+      }),
+    },
+  };
+}
+
 const PlexMediaIdentitySchema = z.object({
   ratingKey: z.string(),
   type: z.string(),
@@ -305,6 +346,50 @@ export function createPlexTools(
     );
   }
 
+  // plex_get_watch_history
+  if (isToolEnabled("plex_get_watch_history")) {
+    server.registerTool(
+      "plex_get_watch_history",
+      {
+        title: "Get global Plex watch history",
+        description:
+          "Get recent playback history across all playable Plex media items; combine accountID values with plex_get_accounts to resolve viewer names",
+        inputSchema: {
+          accountId: z.number().int().optional().describe(
+            "Filter history to a specific Plex account ID",
+          ),
+          start: z.number().int().min(0).optional().describe(
+            "Pagination offset (0-based)",
+          ),
+          size: z.number().int().min(1).max(1_000).optional().default(100)
+            .describe(
+              "Number of history entries to return (default: 100, maximum: 1,000)",
+            ),
+          viewedAtSince: z.number().int().min(0).optional().describe(
+            "Only return plays after this Unix timestamp",
+          ),
+        },
+        outputSchema: z.object({}).catchall(z.unknown()),
+        annotations: { readOnlyHint: true, openWorldHint: false },
+      },
+      wrapToolHandler("plex_get_watch_history", async (args) => {
+        const result = await plexClient.getWatchHistory(config, {
+          accountId: args.accountId,
+          start: args.start,
+          size: args.size,
+          viewedAtSince: args.viewedAtSince,
+        });
+        return {
+          content: [{
+            type: "text",
+            text: JSON.stringify(result, null, 2),
+          }],
+          structuredContent: result,
+        };
+      }),
+    );
+  }
+
   // plex_refresh_library
   if (isToolEnabled("plex_refresh_library")) {
     server.registerTool(
@@ -373,19 +458,21 @@ export function createPlexTools(
         annotations: { readOnlyHint: true, openWorldHint: false },
       },
       wrapToolHandler("plex_get_library_items", async (args) => {
-        const result = await plexClient.getLibraryItems(config, args.key, {
-          type: args.type,
-          studio: args.studio,
-          genre: args.genre,
-          year: args.year,
-          sort: args.sort,
-          start: args.start,
-          size: args.size,
-        });
+        const result = compactLibraryItems(
+          await plexClient.getLibraryItems(config, args.key, {
+            type: args.type,
+            studio: args.studio,
+            genre: args.genre,
+            year: args.year,
+            sort: args.sort,
+            start: args.start,
+            size: args.size,
+          }),
+        );
         return {
           content: [{
             type: "text",
-            text: JSON.stringify(result, slimReplacer, 2),
+            text: JSON.stringify(result, null, 2),
           }],
           structuredContent: result,
         };

--- a/packages/media-server-mcp/src/tools/tool-categories.ts
+++ b/packages/media-server-mcp/src/tools/tool-categories.ts
@@ -61,6 +61,7 @@ export const TOOL_BRANCHES: ToolCategory[] = [
       "plex_get_metadata",
       "plex_get_library_items",
       "plex_get_playback_history",
+      "plex_get_watch_history",
       "plex_get_collections",
       "plex_get_collection_items",
       "plex_create_collection",

--- a/packages/media-server-mcp/tests/resources/runtime-resources_test.ts
+++ b/packages/media-server-mcp/tests/resources/runtime-resources_test.ts
@@ -63,7 +63,7 @@ Deno.test("runtime identity exposes the active Code Mode contract safely at the 
         version: deno.version,
       },
       codeMode: {
-        contractRevision: 2,
+        contractRevision: 3,
         configuredServices: ["radarr", "sonarr", "tmdb", "plex"],
         executionPolicy: "read-only",
         limits: CODEMODE_LIMITS,

--- a/packages/media-server-mcp/tests/tools/codemode-tools_test.ts
+++ b/packages/media-server-mcp/tests/tools/codemode-tools_test.ts
@@ -1545,7 +1545,7 @@ Deno.test("codemode catalog has an explicit reviewed contract for every native t
   };
   const catalog = createCodeModeCatalog(services);
 
-  assertEquals(catalog.length, 104);
+  assertEquals(catalog.length, 105);
   assertEquals(
     new Set(catalog.map((entry) => entry.name)).size,
     catalog.length,
@@ -1631,6 +1631,7 @@ Deno.test("codemode execute projects bounded metadata-heavy cross-service result
       type: "movie",
       title: `Representative title ${id}`,
       summary: "x".repeat(180),
+      Media: [{ Part: [{ file: "x".repeat(1_000) }] }],
     }));
   const crossServiceItems = representativeItems(300);
   const plexItems = representativeItems(600);
@@ -1713,6 +1714,7 @@ Deno.test("codemode execute projects bounded metadata-heavy cross-service result
           })),
         });
         assert(!JSON.stringify(plexProjection).includes("summary"));
+        assert(!JSON.stringify(plexProjection).includes("Media"));
       },
     );
   } finally {

--- a/packages/media-server-mcp/tests/tools/plex-tools-execution_test.ts
+++ b/packages/media-server-mcp/tests/tools/plex-tools-execution_test.ts
@@ -459,6 +459,69 @@ Deno.test(
 );
 
 Deno.test(
+  "plex_get_watch_history - returns global history without an item filter",
+  async () => {
+    let capturedUrl = "";
+    const fetchStub = stub(globalThis, "fetch", (url) => {
+      capturedUrl = url.toString();
+      return Promise.resolve(
+        new Response(
+          JSON.stringify({
+            MediaContainer: {
+              size: 1,
+              totalSize: 1,
+              offset: 0,
+              Metadata: [{
+                historyKey: "/status/sessions/history/1",
+                ratingKey: "123",
+                key: "/library/metadata/123",
+                title: "Pilot",
+                grandparentTitle: "Example Show",
+                type: "episode",
+                viewedAt: 1700000000,
+                accountID: 42,
+              }],
+            },
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        ),
+      );
+    });
+
+    try {
+      const server = new McpServer({ name: "test", version: "1.0.0" });
+      createPlexTools(
+        server,
+        createPlexConfig("http://localhost:32400", "test-plex-token"),
+        () => true,
+      );
+      const { client, cleanup } = await createConnectedClient(server);
+
+      try {
+        const result = await client.callTool({
+          name: "plex_get_watch_history",
+          arguments: { viewedAtSince: 1690000000, size: 1000 },
+        });
+        assertExists(result.structuredContent);
+        assertEquals(result.isError, undefined);
+
+        const requestUrl = new URL(capturedUrl);
+        assertEquals(requestUrl.searchParams.has("metadataItemID"), false);
+        assertEquals(requestUrl.searchParams.get("viewedAt>"), "1690000000");
+        assertEquals(
+          requestUrl.searchParams.get("X-Plex-Container-Size"),
+          "1000",
+        );
+      } finally {
+        await cleanup();
+      }
+    } finally {
+      fetchStub.restore();
+    }
+  },
+);
+
+Deno.test(
   "plex_get_playback_history - rejects page sizes above the maximum",
   async () => {
     const server = new McpServer({ name: "test", version: "1.0.0" });

--- a/packages/plex/mod.ts
+++ b/packages/plex/mod.ts
@@ -11,6 +11,7 @@ export {
   getLibraryItems,
   getMetadata,
   getPlaybackHistory,
+  getWatchHistory,
   type PlexConfig,
   refreshLibrary,
   removeFromCollection,

--- a/packages/plex/src/client.ts
+++ b/packages/plex/src/client.ts
@@ -223,10 +223,28 @@ export function getPlaybackHistory(
   ratingKey: string,
   options: Partial<PlaybackHistoryOptions> = {},
 ): Promise<GetPlaybackHistoryResponse> {
+  return getWatchHistory(config, options, ratingKey);
+}
+
+/**
+ * Get global Plex playback history across all playable media items.
+ *
+ * @param config Plex server configuration.
+ * @param options Optional account, pagination, and timestamp filters.
+ * @param ratingKey Optional internal item filter used by item-specific history.
+ * @returns The matching playback-history events in reverse chronological order.
+ */
+export function getWatchHistory(
+  config: PlexConfig,
+  options: Partial<PlaybackHistoryOptions> = {},
+  ratingKey: string | undefined = undefined,
+): Promise<GetPlaybackHistoryResponse> {
   const searchParams = new URLSearchParams();
-  searchParams.set("metadataItemID", ratingKey);
   searchParams.set("sort", "viewedAt:desc");
 
+  if (ratingKey !== undefined) {
+    searchParams.set("metadataItemID", ratingKey);
+  }
   if (options.accountId !== undefined) {
     searchParams.set("accountID", options.accountId.toString());
   }

--- a/packages/plex/src/types.ts
+++ b/packages/plex/src/types.ts
@@ -464,6 +464,12 @@ interface LibraryMetadataItem {
   originallyAvailableAt: string;
   addedAt: number;
   updatedAt: number;
+  viewCount: number | undefined;
+  lastViewedAt: number | undefined;
+  grandparentTitle: string | undefined;
+  parentTitle: string | undefined;
+  parentIndex: number | undefined;
+  index: number | undefined;
   Genre: GenreItem[];
   Country: CountryItem[];
   Director: DirectorItem[];

--- a/packages/plex/tests/client_test.ts
+++ b/packages/plex/tests/client_test.ts
@@ -12,6 +12,7 @@ import {
   getLibraryItems,
   getMetadata,
   getPlaybackHistory,
+  getWatchHistory,
   type PlexConfig,
   removeFromCollection,
   search,
@@ -437,6 +438,47 @@ Deno.test(
       assertEquals(requestUrl.searchParams.get("X-Plex-Container-Size"), "5");
       assertEquals(requestUrl.searchParams.get("viewedAt>"), "1690000000");
       assertEquals(result.MediaContainer.Metadata?.[0]?.viewedAt, 1700000000);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  },
+);
+
+Deno.test(
+  "getWatchHistory - queries global history without a metadata item filter",
+  async () => {
+    const cfg = createPlexConfig("http://localhost:32400", "fake-token");
+    let capturedUrl = "";
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = (url: string | URL | Request) => {
+      capturedUrl = url.toString();
+      return Promise.resolve(
+        new Response(
+          JSON.stringify({
+            MediaContainer: { size: 0, totalSize: 0, Metadata: [] },
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        ),
+      );
+    };
+
+    try {
+      await getWatchHistory(cfg, {
+        accountId: 42,
+        size: 1000,
+        viewedAtSince: 1690000000,
+      });
+      const requestUrl = new URL(capturedUrl);
+
+      assertEquals(requestUrl.pathname, "/status/sessions/history/all");
+      assertEquals(requestUrl.searchParams.has("metadataItemID"), false);
+      assertEquals(requestUrl.searchParams.get("accountID"), "42");
+      assertEquals(
+        requestUrl.searchParams.get("X-Plex-Container-Size"),
+        "1000",
+      );
+      assertEquals(requestUrl.searchParams.get("viewedAt>"), "1690000000");
+      assertEquals(requestUrl.searchParams.get("sort"), "viewedAt:desc");
     } finally {
       globalThis.fetch = originalFetch;
     }


### PR DESCRIPTION
## Summary

- Add global Plex watch-history queries with account, timestamp, and pagination filters.
- Keep Plex library browsing within Code Mode limits by returning compact structured metadata.
- Publish the new read-only tool through Code Mode and update its compatibility revision.

## Related Issues

None.

## Test Plan

- `deno task fmt`
- `deno task lint`
- `deno task check`
- `deno task test --ignore=.claude/worktrees`
- Live MCP validation of global watch history and a 1,557-item Plex library response.

## Checklist

- [x] `deno check` passes
- [x] `deno fmt` passes
- [x] `deno lint` passes
- [x] `deno task test` passes
- [x] README/CLAUDE.md updated (if tools or resources changed)